### PR TITLE
L3-23 remove demo code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@
 
 /.scannerwork/
 /sonar-project.properties
+
+*.p12

--- a/README.md
+++ b/README.md
@@ -113,3 +113,21 @@ Using Ngrok For Local SSL Cert
 4. Utilize the https url from ngrok when registering your tool with the platform   
 
 Note: Each time you restart ngrok, you will need to change the url of your tool in your registration with the LMS. However, you may restart the tool as much as you like while leaving ngrok running without issue.
+
+Turning Demo/Test Features On/Off
+---------------------------------
+In the `application.properties` file, the following env variables have been added.
+```
+lti13.demoMode=false
+lti13.enableAGS=true
+lti13.enableMembership=false
+lti13.enableDynamicRegistration=false
+lti13.enableDeepLinking=false
+lti13.enableRoleTesting=false
+lti13.enableTokenController=false
+```
+ - `lti13.demoMode` must have a value of `true` for AGS, Membership, or Deep Linking (the LTI Advantage Services) to function regardless of the value of their individual env variables. This is because each of these services is currently a demo.
+ - `lti13.enableAGS` must have a value of `true` in addition to `lti13.demoMode` having a value of `true` for the Assignments and Grades (AGS) demo service to function.
+ - `lti13.enableMembership` must have a value of `true` in addition to `lti13.demoMode` having a value of `true` for the Membership demo service to function.
+ - `lti13.enableDeepLinking` must have a value of `true` in addition to `lti13.demoMode` having a value of `true` for the Deep Linking demo service to function.
+ - The remaining new env vars `lti13.enableDynamicRegistration`, `lti13.enableRoleTesting`, `lti13.enableTokenController` are for test endpoints. `lti13.enableDynamicRegistration` corresponds to the `RegistrationController` which has not been tested. `lti13.enableRoleTesting` corresponds to the `TestController` which I suspect will be deleted as role authorization is not needed. `lti13.enableTokenController` corresponds to `TokenController` which I suspect will be deleted if it remains unused.

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+        </dependency>
 
         <!--Testing-->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
@@ -76,6 +75,19 @@
             <version>5.5.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>3.8.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <!-- Utilities-->
         <dependency>

--- a/src/main/java/net/unicon/lti/controller/app/TestController.java
+++ b/src/main/java/net/unicon/lti/controller/app/TestController.java
@@ -12,6 +12,7 @@
  */
 package net.unicon.lti.controller.app;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -25,6 +26,7 @@ import java.security.Principal;
 
 @Controller
 @RequestMapping(value = TestController.REQUEST_ROOT, produces = MediaType.APPLICATION_JSON_VALUE)
+@ConditionalOnExpression("${lti13.enableRoleTesting}")
 public class TestController {
     static final String REQUEST_ROOT = "api/test";
 

--- a/src/main/java/net/unicon/lti/controller/app/TokenController.java
+++ b/src/main/java/net/unicon/lti/controller/app/TokenController.java
@@ -18,6 +18,7 @@ import io.jsonwebtoken.Jws;
 import net.unicon.lti.exceptions.BadTokenException;
 import net.unicon.lti.service.app.APIJWTService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +33,7 @@ import java.util.List;
 
 @Controller
 @RequestMapping(value = "/api/oauth", produces = MediaType.APPLICATION_JSON_VALUE)
+@ConditionalOnExpression("${lti13.enableTokenController}")
 public class TokenController {
 
     @Autowired

--- a/src/main/java/net/unicon/lti/controller/lti/AgsController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/AgsController.java
@@ -27,6 +27,7 @@ import net.unicon.lti.utils.TextConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -50,6 +51,7 @@ import java.util.Optional;
 @Controller
 @Scope("session")
 @RequestMapping("/ags")
+@ConditionalOnExpression("${lti13.enableAGS}")
 public class AgsController {
 
     static final Logger log = LoggerFactory.getLogger(AgsController.class);

--- a/src/main/java/net/unicon/lti/controller/lti/JWKController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/JWKController.java
@@ -13,11 +13,10 @@
 package net.unicon.lti.controller.lti;
 
 
+import lombok.extern.slf4j.Slf4j;
 import net.unicon.lti.service.lti.LTIDataService;
 import net.unicon.lti.utils.TextConstants;
 import net.unicon.lti.utils.oauth.OAuthUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Controller;
@@ -38,15 +37,13 @@ import java.util.Map;
 /**
  * Serving the public key of the tool.
  */
+@Slf4j
 @Controller
 @Scope("session")
 @RequestMapping("/jwks")
 public class JWKController {
-
     @Autowired
     LTIDataService ltiDataService;
-
-    static final Logger log = LoggerFactory.getLogger(JWKController.class);
 
     @RequestMapping(value = "/jwk", method = RequestMethod.GET, produces = "application/json;")
     @ResponseBody

--- a/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
@@ -28,7 +28,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.LaxRedirectStrategy;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpStatus;
@@ -52,7 +53,6 @@ import java.util.List;
 @Slf4j
 @Controller
 @Scope("session")
-@RequestMapping("/lti3")
 public class LTI3Controller {
     @Autowired
     LTIJWTService ltijwtService;
@@ -63,93 +63,83 @@ public class LTI3Controller {
     @Autowired
     LTIDataService ltiDataService;
 
-    private CloseableHttpClient client = HttpClients.createDefault();
+    LTI3Request lti3Request;
 
-    @RequestMapping({"", "/"})
-    public String lti3(HttpServletRequest req, Model model) {
+    private CloseableHttpClient client = HttpClientBuilder.create().setRedirectStrategy(new LaxRedirectStrategy()).build();
+
+    @PostMapping(value={"/lti3","/lti3/"}, produces = MediaType.TEXT_HTML_VALUE)
+    public void lti3(HttpServletRequest req, HttpServletResponse res)  {
         //First we will get the state, validate it
         String state = req.getParameter("state");
         //We will use this link to find the content to display.
         String link = req.getParameter("link");
         try {
             Jws<Claims> claims = ltijwtService.validateState(state);
-            LTI3Request lti3Request = LTI3Request.getInstance(link); // validates nonce & id_token
+            lti3Request = LTI3Request.getInstance(link); // validates nonce & id_token
             // This is just an extra check that we have added, but it is not necessary.
             // Checking that the clientId in the status matches the one coming with the ltiRequest.
             if (!claims.getBody().get("clientId").equals(lti3Request.getAud())) {
-                if (model != null) {
-                    model.addAttribute(TextConstants.ERROR, " Bad Client Id");
-                    return TextConstants.LTI3ERROR;
-                } else {
-                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid client_id");
-                }
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid client_id");
             }
             // This is just an extra check that we have added, but it is not necessary.
             // Checking that the deploymentId in the status matches the one coming with the ltiRequest.
             if (!claims.getBody().get("ltiDeploymentId").equals(lti3Request.getLtiDeploymentId())) {
-                if (model != null) {
-                    model.addAttribute(TextConstants.ERROR, " Bad Deployment Id");
-                    return TextConstants.LTI3ERROR;
-                } else {
-                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid deployment_id");
-                }
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid deployment_id");
             }
-            //We add the request to the model so it can be displayed. But, in a real application, we would start
-            // processing it here to generate the right answer.
+
             if (!ltiDataService.getDemoMode()) {
-                return "forward:/lti3/target";
+                String target = lti3Request.getLtiTargetLinkUrl();
+                String jwt = req.getParameter("id_token");
+                String redirect = UriComponentsBuilder.fromUriString(target).queryParam("id_token", jwt).build().toUriString();
+                HttpPost httpPost = new HttpPost(redirect);
+                CloseableHttpResponse response = client.execute(httpPost);
+                ByteStreams.copy(response.getEntity().getContent(), res.getOutputStream());
             } else {
-                model.addAttribute("lTI3Request", lti3Request);
-                if (link == null) {
-                    link = lti3Request.getLtiTargetLinkUrl().substring(lti3Request.getLtiTargetLinkUrl().lastIndexOf("?link=") + 6);
-                }
-                if (StringUtils.isNotBlank(link)) {
-                    List<LtiLinkEntity> linkEntity = ltiLinkRepository.findByLinkKeyAndContext(link, lti3Request.getContext());
-                    log.debug("Searching for link " + link + " in the context Key " + lti3Request.getContext().getContextKey() + " And id " + lti3Request.getContext().getContextId());
-                    if (linkEntity.size() > 0) {
-                        model.addAttribute(TextConstants.HTML_CONTENT, linkEntity.get(0).createHtmlFromLink());
-                    } else {
-                        model.addAttribute(TextConstants.HTML_CONTENT, "<b> No element was found for that context and linkKey</b>");
-                    }
-                } else {
-                    model.addAttribute(TextConstants.HTML_CONTENT, "<b> No element was requested or it doesn't exists </b>");
-                }
-                if (lti3Request.getLtiMessageType().equals(LtiStrings.LTI_MESSAGE_TYPE_DEEP_LINKING) && ltiDataService.getDeepLinkingEnabled()) {
-                    //Let's create the LtiLinkEntity's in our database
-                    //This should be done AFTER the user selects the link in the content selector, and we are doing it before
-                    //just to keep it simple. The ideal process would be, the user selects a link, sends it to the platform and
-                    // we create the LtiLinkEntity in our code after that.
-                    LtiLinkEntity ltiLinkEntity = new LtiLinkEntity("1234", lti3Request.getContext(), "My Test Link");
-                    if (ltiLinkRepository.findByLinkKeyAndContext(ltiLinkEntity.getLinkKey(), ltiLinkEntity.getContext()).size() == 0) {
-                        ltiLinkRepository.save(ltiLinkEntity);
-                    }
-                    LtiLinkEntity ltiLinkEntity2 = new LtiLinkEntity("4567", lti3Request.getContext(), "Another Link");
-                    if (ltiLinkRepository.findByLinkKeyAndContext(ltiLinkEntity2.getLinkKey(), ltiLinkEntity2.getContext()).size() == 0) {
-                        ltiLinkRepository.save(ltiLinkEntity2);
-                    }
-                    return "lti3DeepLink";
-                } else if (lti3Request.getLtiMessageType().equals(LtiStrings.LTI_MESSAGE_TYPE_DEEP_LINKING)) {
-                    return TextConstants.LTI3ERROR;
-                }
-                return "lti3Result";
+                res.sendRedirect("/demo?link=" + link);
             }
         } catch (SignatureException ex) {
-            model.addAttribute(TextConstants.ERROR, ex.getMessage());
-            return TextConstants.LTI3ERROR;
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid signature");
+        } catch (IOException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Bad Request");
         }
     }
 
-    @PostMapping(value = "/target", produces = MediaType.TEXT_HTML_VALUE)
-    public void getExternalPage(HttpServletRequest req, HttpServletResponse res) throws IOException {
+    @RequestMapping("/demo")
+    public String demo(HttpServletRequest req, Model model) {
         String link = req.getParameter("link");
-        LTI3Request lti3Request = LTI3Request.getInstance(link);
-        String target = lti3Request.getLtiTargetLinkUrl();
-        String jwt = req.getParameter("id_token");
-        String redirect = UriComponentsBuilder.fromUriString(target).queryParam("id_token", jwt).build().toUriString();
-
-        HttpPost httpPost = new HttpPost(redirect);
-        CloseableHttpResponse response = client.execute(httpPost);
-        ByteStreams.copy(response.getEntity().getContent(), res.getOutputStream());
+        model.addAttribute("lTI3Request", lti3Request);
+        if (link == null) {
+            link = lti3Request.getLtiTargetLinkUrl().substring(lti3Request.getLtiTargetLinkUrl().lastIndexOf("?link=") + 6);
+        }
+        if (StringUtils.isNotBlank(link)) {
+            List<LtiLinkEntity> linkEntity = ltiLinkRepository.findByLinkKeyAndContext(link, lti3Request.getContext());
+            log.debug("Searching for link " + link + " in the context Key " + lti3Request.getContext().getContextKey() + " And id " + lti3Request.getContext().getContextId());
+            if (linkEntity.size() > 0) {
+                model.addAttribute(TextConstants.HTML_CONTENT, linkEntity.get(0).createHtmlFromLink());
+            } else {
+                model.addAttribute(TextConstants.HTML_CONTENT, "<b> No element was found for that context and linkKey</b>");
+            }
+        } else {
+            model.addAttribute(TextConstants.HTML_CONTENT, "<b> No element was requested or it doesn't exists </b>");
+        }
+        if (lti3Request.getLtiMessageType().equals(LtiStrings.LTI_MESSAGE_TYPE_DEEP_LINKING) && ltiDataService.getDeepLinkingEnabled()) {
+            //Let's create the LtiLinkEntity's in our database
+            //This should be done AFTER the user selects the link in the content selector, and we are doing it before
+            //just to keep it simple. The ideal process would be, the user selects a link, sends it to the platform and
+            // we create the LtiLinkEntity in our code after that.
+            LtiLinkEntity ltiLinkEntity = new LtiLinkEntity("1234", lti3Request.getContext(), "My Test Link");
+            if (ltiLinkRepository.findByLinkKeyAndContext(ltiLinkEntity.getLinkKey(), ltiLinkEntity.getContext()).size() == 0) {
+                ltiLinkRepository.save(ltiLinkEntity);
+            }
+            LtiLinkEntity ltiLinkEntity2 = new LtiLinkEntity("4567", lti3Request.getContext(), "Another Link");
+            if (ltiLinkRepository.findByLinkKeyAndContext(ltiLinkEntity2.getLinkKey(), ltiLinkEntity2.getContext()).size() == 0) {
+                ltiLinkRepository.save(ltiLinkEntity2);
+            }
+            return "lti3DeepLink";
+        } else if (lti3Request.getLtiMessageType().equals(LtiStrings.LTI_MESSAGE_TYPE_DEEP_LINKING)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Deep Linking Disabled");
+        }
+        return "lti3Result";
     }
 
 }

--- a/src/main/java/net/unicon/lti/controller/lti/MembershipController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/MembershipController.java
@@ -13,6 +13,7 @@
 package net.unicon.lti.controller.lti;
 
 
+import lombok.extern.slf4j.Slf4j;
 import net.unicon.lti.exceptions.ConnectionException;
 import net.unicon.lti.model.LtiContextEntity;
 import net.unicon.lti.model.PlatformDeployment;
@@ -21,9 +22,8 @@ import net.unicon.lti.model.oauth2.LTIToken;
 import net.unicon.lti.repository.LtiContextRepository;
 import net.unicon.lti.repository.PlatformDeploymentRepository;
 import net.unicon.lti.service.lti.AdvantageMembershipService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -38,13 +38,12 @@ import java.util.Optional;
  * This LTI 3 redirect controller will retrieve the LTI3 requests and redirect them to the right page.
  * Everything that arrives here is filtered first by the LTI3OAuthProviderProcessingFilter
  */
+@Slf4j
 @Controller
 @Scope("session")
 @RequestMapping("/membership")
+@ConditionalOnExpression("${lti13.enableMembership}")
 public class MembershipController {
-
-    static final Logger log = LoggerFactory.getLogger(MembershipController.class);
-
     @Autowired
     LtiContextRepository ltiContextRepository;
 

--- a/src/main/java/net/unicon/lti/controller/lti/OIDCController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/OIDCController.java
@@ -130,7 +130,7 @@ public class OIDCController {
             // We add that information so the thymeleaf template can display it (and prepare the links)
             //model.addAllAttributes(parameters);
             // These 3 are to display what we received from the platform.
-            if (ltiDataService.getDemoMode()){
+            if (ltiDataService.getDemoMode()) {
                 model.addAllAttributes(parameters);
                 model.addAttribute("initiation_dto", loginInitiationDTO);
                 model.addAttribute("client_id_received", clientIdValue);
@@ -205,7 +205,8 @@ public class OIDCController {
         authRequestMap.put("nonce", nonce);  //The nonce
         authRequestMap.put("nonce_hash", nonceHash);  //The hash value of the nonce
         authRequestMap.put("prompt", NONE);  //Always this value, as specified in the standard.
-        authRequestMap.put("redirect_uri", ltiDataService.getLocalUrl() + "/lti3");  // One of the valids reditect uris.
+        //authRequestMap.put("redirect_uri", loginInitiationDTO.getTargetLinkUri());
+        authRequestMap.put("redirect_uri", ltiDataService.getLocalUrl() + "/lti3");  // One of the valid redirect uris.
         authRequestMap.put("response_mode", FORM_POST); //Always this value, as specified in the standard.
         authRequestMap.put("response_type", ID_TOKEN); //Always this value, as specified in the standard.
         authRequestMap.put("scope", OPEN_ID);  //Always this value, as specified in the standard.

--- a/src/main/java/net/unicon/lti/controller/lti/OIDCController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/OIDCController.java
@@ -205,7 +205,6 @@ public class OIDCController {
         authRequestMap.put("nonce", nonce);  //The nonce
         authRequestMap.put("nonce_hash", nonceHash);  //The hash value of the nonce
         authRequestMap.put("prompt", NONE);  //Always this value, as specified in the standard.
-        //authRequestMap.put("redirect_uri", loginInitiationDTO.getTargetLinkUri());
         authRequestMap.put("redirect_uri", ltiDataService.getLocalUrl() + "/lti3");  // One of the valid redirect uris.
         authRequestMap.put("response_mode", FORM_POST); //Always this value, as specified in the standard.
         authRequestMap.put("response_type", ID_TOKEN); //Always this value, as specified in the standard.

--- a/src/main/java/net/unicon/lti/controller/lti/RegistrationController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/RegistrationController.java
@@ -12,6 +12,7 @@
  */
 package net.unicon.lti.controller.lti;
 
+import lombok.extern.slf4j.Slf4j;
 import net.unicon.lti.exceptions.ConnectionException;
 import net.unicon.lti.model.lti.dto.PlatformRegistrationDTO;
 import net.unicon.lti.model.lti.dto.ToolConfigurationDTO;
@@ -22,10 +23,9 @@ import net.unicon.lti.service.lti.LTIDataService;
 import net.unicon.lti.service.lti.RegistrationService;
 import net.unicon.lti.utils.LtiStrings;
 import net.unicon.lti.utils.TextConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.Scope;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -55,13 +55,12 @@ import java.util.List;
  * Sample Key "key" and secret "secret"
  */
 @SuppressWarnings("ALL")
+@Slf4j
 @Controller
 @Scope("session")
 @RequestMapping("/registration")
+@ConditionalOnExpression("${lti13.enableDynamicRegistration}")
 public class RegistrationController {
-
-    static final Logger log = LoggerFactory.getLogger(RegistrationController.class);
-
     @Autowired
     PlatformDeploymentRepository platformDeploymentRepository;
 
@@ -73,7 +72,6 @@ public class RegistrationController {
 
     @Value("${application.url}")
     private String localUrl;
-
 
     @Value("${application.name}")
     private String clientName;

--- a/src/main/java/net/unicon/lti/service/lti/LTIDataService.java
+++ b/src/main/java/net/unicon/lti/service/lti/LTIDataService.java
@@ -40,7 +40,11 @@ public interface LTIDataService {
 
     void setOwnPublicKey(String ownPublicKey);
 
-    Boolean getDemoMode();
+    boolean getDemoMode();
 
-    void setDemoMode(Boolean demoMode);
+    void setDemoMode(boolean demoMode);
+
+    boolean getDeepLinkingEnabled();
+
+    void setDeepLinkingEnabled(boolean deepLinkingEnabled);
 }

--- a/src/main/java/net/unicon/lti/service/lti/impl/LTIDataServiceImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/LTIDataServiceImpl.java
@@ -12,6 +12,7 @@
  */
 package net.unicon.lti.service.lti.impl;
 
+import lombok.extern.slf4j.Slf4j;
 import net.unicon.lti.exceptions.DataServiceException;
 import net.unicon.lti.model.LtiContextEntity;
 import net.unicon.lti.model.LtiLinkEntity;
@@ -22,8 +23,6 @@ import net.unicon.lti.repository.AllRepositories;
 import net.unicon.lti.service.lti.LTIDataService;
 import net.unicon.lti.utils.LtiStrings;
 import net.unicon.lti.utils.lti.LTI3Request;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -36,11 +35,9 @@ import java.util.List;
  * This manages all the data processing for the LTIRequest (and for LTI in general)
  * Necessary to get appropriate TX handling and service management
  */
+@Slf4j
 @Service
 public class LTIDataServiceImpl implements LTIDataService {
-
-    static final Logger log = LoggerFactory.getLogger(LTIDataServiceImpl.class);
-
     @Autowired
     AllRepositories repos;
 
@@ -56,6 +53,9 @@ public class LTIDataServiceImpl implements LTIDataService {
 
     @Value("${lti13.demoMode:false}")
     private boolean demoMode;
+
+    @Value("${lti13.enableDeepLinking}")
+    private boolean deepLinkingEnabled;
 
 
     /**
@@ -373,12 +373,22 @@ public class LTIDataServiceImpl implements LTIDataService {
     }
 
     @Override
-    public Boolean getDemoMode() {
+    public boolean getDemoMode() {
         return demoMode;
     }
 
     @Override
-    public void setDemoMode(Boolean demoMode) {
+    public void setDemoMode(boolean demoMode) {
         this.demoMode = demoMode;
+    }
+
+    @Override
+    public boolean getDeepLinkingEnabled() {
+        return deepLinkingEnabled;
+    }
+
+    @Override
+    public void setDeepLinkingEnabled(boolean deepLinkingEnabled) {
+        this.deepLinkingEnabled = deepLinkingEnabled;
     }
 }

--- a/src/main/java/net/unicon/lti/service/lti/impl/LTIJWTServiceImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/LTIJWTServiceImpl.java
@@ -22,6 +22,7 @@ import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.SigningKeyResolverAdapter;
+import lombok.extern.slf4j.Slf4j;
 import net.unicon.lti.model.PlatformDeployment;
 import net.unicon.lti.service.lti.LTIDataService;
 import net.unicon.lti.service.lti.LTIJWTService;
@@ -29,8 +30,6 @@ import net.unicon.lti.utils.TextConstants;
 import net.unicon.lti.utils.oauth.OAuthUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.DateUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -47,15 +46,11 @@ import java.util.UUID;
  * This manages all the data processing for the LTIRequest (and for LTI in general)
  * Necessary to get appropriate TX handling and service management
  */
+@Slf4j
 @Service
 public class LTIJWTServiceImpl implements LTIJWTService {
-
-    static final Logger log = LoggerFactory.getLogger(LTIJWTServiceImpl.class);
-
     @Autowired
     LTIDataService ltiDataService;
-
-    String error;
 
     /**
      * This will check that the state has been signed by us and retrieve the issuer private key.

--- a/src/main/java/net/unicon/lti/utils/lti/LTI3Request.java
+++ b/src/main/java/net/unicon/lti/utils/lti/LTI3Request.java
@@ -23,6 +23,7 @@ import io.jsonwebtoken.JwsHeader;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SigningKeyResolverAdapter;
+import lombok.extern.slf4j.Slf4j;
 import net.unicon.lti.config.ApplicationConfig;
 import net.unicon.lti.exceptions.DataServiceException;
 import net.unicon.lti.model.LtiContextEntity;
@@ -35,8 +36,6 @@ import net.unicon.lti.service.lti.LTIDataService;
 import net.unicon.lti.service.lti.impl.LTIDataServiceImpl;
 import net.unicon.lti.utils.LtiStrings;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import org.thymeleaf.util.ListUtils;
@@ -75,13 +74,10 @@ import java.util.Map;
  *
  */
 @SuppressWarnings("ConstantConditions")
+@Slf4j
 public class LTI3Request {
-
-    static final Logger log = LoggerFactory.getLogger(LTI3Request.class);
-
     HttpServletRequest httpServletRequest;
     LTIDataService ltiDataService;
-
 
     // these are populated by the loadLTIDataFromDB operation
     PlatformDeployment key;
@@ -280,15 +276,15 @@ public class LTI3Request {
             }
         });
         Jws<Claims> jws = parser.parseClaimsJws(jwt);
+
         //This is just for logging.
         Enumeration<String> sessionAttributes = httpServletRequest.getSession().getAttributeNames();
-        log.info("----------------------BEFORE---------------------------------------------------------------------------------");
-        while (sessionAttributes.hasMoreElements()) {
+        while (log.isDebugEnabled() && sessionAttributes.hasMoreElements()) {
+            log.info("----------------------BEFORE---------------------------------------------------------------------------------");
             String attName = sessionAttributes.nextElement();
             log.debug(attName + " : " + httpServletRequest.getSession().getAttribute(attName));
-
+            log.info("-------------------------------------------------------------------------------------------------------");
         }
-        log.info("-------------------------------------------------------------------------------------------------------");
 
         //We check that the LTI request is a valid LTI Request and has the right type.
         String isLTI3Request = isLTI3Request(jws);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,13 @@ server.port=443
 #server.tomcat.internal-proxies=.*
 
 #if true, it will display the LTI messages and never jump to the app part. Set to false for prod.
-lti13.demoMode = true
+lti13.demoMode=false
+lti13.enableAGS=true
+lti13.enableMembership=false
+lti13.enableDynamicRegistration=false
+lti13.enableDeepLinking=false
+lti13.enableRoleTesting=false
+lti13.enableTokenController=false
 
 ## thymeleaf base settings
 spring.thymeleaf.mode=HTML5

--- a/src/test/java/net/unicon/lti/controller/lti/ConfigurationControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/ConfigurationControllerTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 @WebMvcTest(ConfigurationController.class)
 public class ConfigurationControllerTest {
     private PlatformDeployment platformDeployment = new PlatformDeployment();
-    private ResponseEntity<PlatformDeployment> platformDeploymentResponseEntity;
 
     @InjectMocks
     private ConfigurationController configurationController = new ConfigurationController();

--- a/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
@@ -1,0 +1,159 @@
+package net.unicon.lti.controller.lti;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import net.unicon.lti.service.lti.LTIDataService;
+import net.unicon.lti.service.lti.LTIJWTService;
+import net.unicon.lti.utils.lti.LTI3Request;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(LTI3Controller.class)
+public class LTI3ControllerTest {
+    private static String VALID_STATE = "eyJraWQiOiJPV05LRVkiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJsdGlTdGFydGVyIiwic3ViIjoiaHR0cHM6Ly9jYW52YXMuaW5zdHJ1Y3R1cmUuY29tIiwiYXVkIjoiOTcxNDAwMDAwMDAwMDAyMzAiLCJleHAiOjE2MzM1NDE3MTAsIm5iZiI6MTYzMzUzODExMCwiaWF0IjoxNjMzNTM4MTEwLCJqdGkiOiJkYmIzNWI5Ny02MTEzLTQ3YmUtYWYxOC1jYTg3MTM5NTkzMWEiLCJvcmlnaW5hbF9pc3MiOiJodHRwczovL2NhbnZhcy5pbnN0cnVjdHVyZS5jb20iLCJsb2dpbkhpbnQiOiI0MDdhNDE4MjUwN2YwZjM3YTU0ZWM1NWQ1MDE5MzljMWQzZDEwMmU2IiwibHRpTWVzc2FnZUhpbnQiOiJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpJVXpJMU5pSjkuZXlKMlpYSnBabWxsY2lJNkltRXdOek16WldZelpXUXlNbUl5WlRCa1ltSXlZakpoTlRZME5qWm1OakpoTXpFMlptWXlNMlptTkdKa09XSTVZVFpqWmpaaVlqUTVZbVkwTXpsa05UUmlZalJtWXpaalpETmpPRFE1TldGbVpEZzJNbVZoTXpkbE1UZzRORGcyTnpJNFlqUXhPVGcwWm1WbFpqVXhPVEF5TnpGbFptTmxOR0V4T0RVM05UZ3dJaXdpWTJGdWRtRnpYMlJ2YldGcGJpSTZJblZ1YVdOdmJpNXBibk4wY25WamRIVnlaUzVqYjIwaUxDSmpiMjUwWlhoMFgzUjVjR1VpT2lKRGIzVnljMlVpTENKamIyNTBaWGgwWDJsa0lqbzVOekUwTURBd01EQXdNREF3TXpNME9Dd2lZMkZ1ZG1GelgyeHZZMkZzWlNJNkltVnVJaXdpWlhod0lqb3hOak16TlRNNE5EQTRmUS5lRjh5a1BIVjY4M0FyaFA2MzZUdlNLQ2tDSUxfWEJEX2tFSENfLVJKVHhnIiwidGFyZ2V0TGlua1VyaSI6Imh0dHBzOi8vZ29sZGlsb2Nrcy5sdW1lbmxlYXJuaW5nLmNvbS9zdHVkeV9wbGFuLzdjM2EzOTE1LWZmZGEtNGU4Ny05MTQ5LTE2YzFhYzUyM2IyZj9laWQ9YUd3d0x3QndrdFpnelp0cENKWGVaZyIsImNsaWVudElkIjoiOTcxNDAwMDAwMDAwMDAyMzAiLCJsdGlEZXBsb3ltZW50SWQiOiI0NjE6NTQ0MGEwODQyMmFiMWVlNzc5NGEwNTg4YjVlNGNiNGEwOTRjNDI1NiIsImNvbnRyb2xsZXIiOiIvb2lkYy9sb2dpbl9pbml0aWF0aW9ucyJ9.MyLodskYaqWNDqMbjQpmB8izEEfGRAI58KvMqtaXtkP0RL9SKFLV8hTOHPZsDhgmgGTDL71wRa6kxLEEBiXImDMDSpgkTZIgB3vf1vBmcBz03zZWa0uHHVlyLxQwWJTB65E-w6RlxJuM9wphxUVpdvRXhBr1jHiVKGdgFOm2MkJNKMOdEIQ7sT1l7anTElvcEOtYt7KqSxLFPDRORvSf1Pv3gbY5_IBR1SjLZw3h788_BFH9QSqU4yhJxHdn-tFBoycdnjJ9qqtFor6m7m44U76kDpjCU3b5XLFWOogqbb8sbTLgfwLk0-UFQTENOOUiWih1wA6Fk66vuMX3yHXUOw";
+    private static String ID_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjIwMjEtMDktMDFUMDA6MTQ6MzdaIn0.eyJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS9jbGFpbS9tZXNzYWdlX3R5cGUiOiJMdGlSZXNvdXJjZUxpbmtSZXF1ZXN0IiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vdmVyc2lvbiI6IjEuMy4wIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vcmVzb3VyY2VfbGluayI6eyJpZCI6IjcxZTViNWNiLTZmMDUtNGQ1My1iN2U5LWQxMmVjZDQ3NWU3NiIsImRlc2NyaXB0aW9uIjoiIiwidGl0bGUiOiJTdHVkeSBQbGFuOiBUaGUgRXRpb2xvZ3kgYW5kIFRyZWF0bWVudCBvZiBNZW50YWwgRGlzb3JkZXJzIiwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJhdWQiOiI5NzE0MDAwMDAwMDAwMDIzMCIsImF6cCI6Ijk3MTQwMDAwMDAwMDAwMjMwIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vZGVwbG95bWVudF9pZCI6IjQ2MTo1NDQwYTA4NDIyYWIxZWU3Nzk0YTA1ODhiNWU0Y2I0YTA5NGM0MjU2IiwiZXhwIjoxNjMzNTQyMzczLCJpYXQiOjE2MzM1Mzg3NzMsImlzcyI6Imh0dHBzOi8vY2FudmFzLmluc3RydWN0dXJlLmNvbSIsIm5vbmNlIjoiNWQwNGNiMTJmNDVkZjZlZTM3M2M0MmExY2E0Y2RiZTA4ZTJiZmE4ZTVmN2M2NjJhY2EzZjY1NjA2ODdmZGM0NyIsInN1YiI6IjRmM2QxMmRmLWUxYWUtNDg0Zi04YjlhLWI2Njc4NjRlODEwMCIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL3RhcmdldF9saW5rX3VyaSI6Imh0dHBzOi8vZ29sZGlsb2Nrcy5sdW1lbmxlYXJuaW5nLmNvbS9zdHVkeV9wbGFuLzdjM2EzOTE1LWZmZGEtNGU4Ny05MTQ5LTE2YzFhYzUyM2IyZj9laWQ9YUd3d0x3QndrdFpnelp0cENKWGVaZyIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2NvbnRleHQiOnsiaWQiOiIwYTQ3ZGU5MWNmODRlZTE0N2Y2ZTUzNDE5NTk4ODUwODUwNGQzZTgyIiwibGFiZWwiOiJtZ3dvemR6LWx1bWVuIiwidGl0bGUiOiJtZ3dvemR6IEx1bWVuIFRlc3QiLCJ0eXBlIjpbImh0dHA6Ly9wdXJsLmltc2dsb2JhbC5vcmcvdm9jYWIvbGlzL3YyL2NvdXJzZSNDb3Vyc2VPZmZlcmluZyJdLCJ2YWxpZGF0aW9uX2NvbnRleHQiOm51bGwsImVycm9ycyI6eyJlcnJvcnMiOnt9fX0sImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL3Rvb2xfcGxhdGZvcm0iOnsiZ3VpZCI6InBvdDI4eU5wRFNaczFGdk1RYTQyTWlQV2xST0xRQ0FlZHpRWDZNYzI6Y2FudmFzLWxtcyIsIm5hbWUiOiJVbmljb24iLCJ2ZXJzaW9uIjoiY2xvdWQiLCJwcm9kdWN0X2ZhbWlseV9jb2RlIjoiY2FudmFzIiwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS9jbGFpbS9sYXVuY2hfcHJlc2VudGF0aW9uIjp7ImRvY3VtZW50X3RhcmdldCI6ImlmcmFtZSIsImhlaWdodCI6bnVsbCwid2lkdGgiOm51bGwsInJldHVybl91cmwiOiJodHRwczovL3VuaWNvbi5pbnN0cnVjdHVyZS5jb20vY291cnNlcy8zMzQ4L2V4dGVybmFsX2NvbnRlbnQvc3VjY2Vzcy9leHRlcm5hbF90b29sX3JlZGlyZWN0IiwibG9jYWxlIjoiZW4iLCJ2YWxpZGF0aW9uX2NvbnRleHQiOm51bGwsImVycm9ycyI6eyJlcnJvcnMiOnt9fX0sImxvY2FsZSI6ImVuIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vcm9sZXMiOlsiaHR0cDovL3B1cmwuaW1zZ2xvYmFsLm9yZy92b2NhYi9saXMvdjIvaW5zdGl0dXRpb24vcGVyc29uI0FkbWluaXN0cmF0b3IiLCJodHRwOi8vcHVybC5pbXNnbG9iYWwub3JnL3ZvY2FiL2xpcy92Mi9pbnN0aXR1dGlvbi9wZXJzb24jSW5zdHJ1Y3RvciIsImh0dHA6Ly9wdXJsLmltc2dsb2JhbC5vcmcvdm9jYWIvbGlzL3YyL2luc3RpdHV0aW9uL3BlcnNvbiNTdHVkZW50IiwiaHR0cDovL3B1cmwuaW1zZ2xvYmFsLm9yZy92b2NhYi9saXMvdjIvbWVtYmVyc2hpcCNJbnN0cnVjdG9yIiwiaHR0cDovL3B1cmwuaW1zZ2xvYmFsLm9yZy92b2NhYi9saXMvdjIvc3lzdGVtL3BlcnNvbiNVc2VyIl0sImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2N1c3RvbSI6eyJkdWVfYXQiOiIkQ2FudmFzLmFzc2lnbm1lbnQuZHVlQXQuaXNvODYwMSIsImxvY2tfYXQiOiIkQ2FudmFzLmFzc2lnbm1lbnQubG9ja0F0Lmlzbzg2MDEiLCJ1bmxvY2tfYXQiOiIkQ2FudmFzLmFzc2lnbm1lbnQudW5sb2NrQXQuaXNvODYwMSIsImNhbnZhc191c2VyX2lkIjozODYsImNhbnZhc19sb2dpbl9pZCI6Im1nd296ZHpAdW5pY29uLm5ldCIsImNhbnZhc19jb3Vyc2VfaWQiOjMzNDgsImNhbnZhc191c2VyX25hbWUiOiJtZ3dvemR6QHVuaWNvbi5uZXQiLCJjYW52YXNfYXNzaWdubWVudF9pZCI6NjI3MX0sImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2x0aTExX2xlZ2FjeV91c2VyX2lkIjoiNDA3YTQxODI1MDdmMGYzN2E1NGVjNTVkNTAxOTM5YzFkM2QxMDJlNiIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2x0aTFwMSI6eyJ1c2VyX2lkIjoiNDA3YTQxODI1MDdmMGYzN2E1NGVjNTVkNTAxOTM5YzFkM2QxMDJlNiIsInZhbGlkYXRpb25fY29udGV4dCI6bnVsbCwiZXJyb3JzIjp7ImVycm9ycyI6e319fSwiZXJyb3JzIjp7ImVycm9ycyI6e319LCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS1hZ3MvY2xhaW0vZW5kcG9pbnQiOnsic2NvcGUiOlsiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGktYWdzL3Njb3BlL2xpbmVpdGVtIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGktYWdzL3Njb3BlL2xpbmVpdGVtLnJlYWRvbmx5IiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGktYWdzL3Njb3BlL3Jlc3VsdC5yZWFkb25seSIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpLWFncy9zY29wZS9zY29yZSJdLCJsaW5laXRlbXMiOiJodHRwczovL3VuaWNvbi5pbnN0cnVjdHVyZS5jb20vYXBpL2x0aS9jb3Vyc2VzLzMzNDgvbGluZV9pdGVtcyIsImxpbmVpdGVtIjoiaHR0cHM6Ly91bmljb24uaW5zdHJ1Y3R1cmUuY29tL2FwaS9sdGkvY291cnNlcy8zMzQ4L2xpbmVfaXRlbXMvNTAzIiwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJwaWN0dXJlIjoiaHR0cHM6Ly9jYW52YXMuaW5zdHJ1Y3R1cmUuY29tL2ltYWdlcy9tZXNzYWdlcy9hdmF0YXItNTAucG5nIiwiZW1haWwiOiJtZ3dvemR6QHVuaWNvbi5uZXQiLCJuYW1lIjoiTWFyeSBHd296ZHoiLCJnaXZlbl9uYW1lIjoiTWFyeSIsImZhbWlseV9uYW1lIjoiR3dvemR6IiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vbGlzIjp7InBlcnNvbl9zb3VyY2VkaWQiOiJtZ3dvemR6IiwiY291cnNlX29mZmVyaW5nX3NvdXJjZWRpZCI6bnVsbCwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS1ucnBzL2NsYWltL25hbWVzcm9sZXNlcnZpY2UiOnsiY29udGV4dF9tZW1iZXJzaGlwc191cmwiOiJodHRwczovL3VuaWNvbi5pbnN0cnVjdHVyZS5jb20vYXBpL2x0aS9jb3Vyc2VzLzMzNDgvbmFtZXNfYW5kX3JvbGVzIiwic2VydmljZV92ZXJzaW9ucyI6WyIyLjAiXSwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJodHRwczovL3d3dy5pbnN0cnVjdHVyZS5jb20vcGxhY2VtZW50IjpudWxsfQ.qN6MqcitF8VHuMVk_YmuXnKN43A1TgdjbSV8zHxT6SS5uZo8vtTB2GBGmqPpsknTmJPNijpQsPMoeLN3kKAvkpJ0RJPWMYud89a1SGnons8HuqXxACUCwUa7Lki8j7xSIXB6tgXQqzkrHCPmsBwLQy6rAYseiDNpsLkzIZzBAZjt89262i_UxRScJkhdPF4GEQDw4d2d1YMM5cmSy039BZZyT7AOV4q3qjo_BeFlQ5QJjXDtXGZ5VIcOuyLipAcrG8a2llXd8gLDkxkD0gIwI_zZX2fG-XKHc_co_gp45L2fVz09vKS5R-yCiooZgktOBoe0OEY8vHfCbBk4Vj2sxg";
+
+    @InjectMocks
+    private LTI3Controller lti3Controller = new LTI3Controller();
+
+    @MockBean
+    private LTIJWTService ltijwtService;
+
+    @MockBean
+    private LTIDataService ltiDataService;
+
+    @Mock
+    private HttpServletRequest req;
+
+    @Mock
+    private HttpServletResponse res;
+
+    @Mock
+    Jws<Claims> jwsClaims;
+
+    @Mock
+    Claims claims;
+
+    @Mock
+    LTI3Request lti3Request;
+
+    @Mock
+    CloseableHttpClient client;
+
+    private static MockedStatic<LTI3Request> lti3RequestMockedStatic;
+
+    private final PrintStream standardOut = System.out;
+    private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+
+
+    @Configuration
+    static class ContextConfiguration {
+
+    }
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        lti3RequestMockedStatic = Mockito.mockStatic(LTI3Request.class);
+        when(req.getParameter("state")).thenReturn(VALID_STATE);
+        when(req.getParameter("link")).thenReturn("https://tool.com/test");
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(jwsClaims.getBody()).thenReturn(claims);
+        when(ltijwtService.validateState(VALID_STATE)).thenReturn(jwsClaims);
+        lti3RequestMockedStatic.when(() -> LTI3Request.getInstance("https://tool.com/test")).thenReturn(lti3Request);
+        System.setOut(new PrintStream(outputStreamCaptor));
+    }
+
+    @AfterEach
+    public void close() {
+        lti3RequestMockedStatic.close();
+    }
+
+    @Test
+    public void testLTI3InvalidClientId() {
+        when(claims.get("clientId")).thenReturn("client-id-1");
+        when(lti3Request.getAud()).thenReturn("bad-client-id");
+
+        ResponseStatusException exception = Assertions.assertThrows(ResponseStatusException.class, () -> {lti3Controller.lti3(req, null);});
+        Mockito.verify(ltijwtService).validateState(VALID_STATE);
+        assertEquals(exception.getStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getReason(), "Invalid client_id");
+    }
+
+    @Test
+    public void testLTI3InvalidDeploymentIdAndValidClientId() {
+        when(claims.get("clientId")).thenReturn("client-id-1");
+        when(claims.get("ltiDeploymentId")).thenReturn("deployment-id-1");
+        when(lti3Request.getAud()).thenReturn("client-id-1");
+        when(lti3Request.getLtiDeploymentId()).thenReturn("bad-deployment-id");
+
+        ResponseStatusException exception = Assertions.assertThrows(ResponseStatusException.class, () -> {lti3Controller.lti3(req, null);});
+        Mockito.verify(ltijwtService).validateState(VALID_STATE);
+        assertEquals(exception.getStatus(), HttpStatus.BAD_REQUEST);
+        assertEquals(exception.getReason(), "Invalid deployment_id");
+    }
+
+    @Test
+    public void testLTI3DemoModeOff() {
+        when(claims.get("clientId")).thenReturn("client-id-1");
+        when(claims.get("ltiDeploymentId")).thenReturn("deployment-id-1");
+        when(lti3Request.getAud()).thenReturn("client-id-1");
+        when(lti3Request.getLtiDeploymentId()).thenReturn("deployment-id-1");
+        when(ltiDataService.getDemoMode()).thenReturn(false);
+
+        String response = lti3Controller.lti3(req, null);
+        Mockito.verify(ltijwtService).validateState(VALID_STATE);
+        Mockito.verify(ltiDataService).getDemoMode();
+        assertEquals("forward:/lti3/target", response);
+    }
+
+    @Test
+    public void testTarget() {
+        try {
+            String testPostResponse = "testing response";
+            ServletOutputStream outputStream = Mockito.mock(ServletOutputStream.class);
+            when(res.getOutputStream()).thenReturn(outputStream);
+            when(lti3Request.getLtiTargetLinkUrl()).thenReturn("https://tool.com/test");
+            CloseableHttpResponse response = Mockito.mock(CloseableHttpResponse.class);
+            HttpEntity entity = Mockito.mock(HttpEntity.class);
+            when(entity.getContent()).thenReturn(IOUtils.toInputStream(testPostResponse, "UTF-8"));
+            when(response.getEntity()).thenReturn(entity);
+            when(client.execute(any(HttpPost.class))).thenReturn(response);
+            lti3Controller.getExternalPage(req, res);
+            Mockito.verify(client).execute(any(HttpPost.class));
+            Mockito.verify(outputStream).write(any(byte[].class), eq(0), eq(testPostResponse.length()));
+        } catch (IOException e) {
+            fail("IOException should not be thrown.");
+        }
+    }
+}

--- a/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
@@ -28,9 +28,7 @@ import org.springframework.web.server.ResponseStatusException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -72,10 +70,6 @@ public class LTI3ControllerTest {
 
     private static MockedStatic<LTI3Request> lti3RequestMockedStatic;
 
-    private final PrintStream standardOut = System.out;
-    private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
-
-
     @Configuration
     static class ContextConfiguration {
 
@@ -91,7 +85,6 @@ public class LTI3ControllerTest {
         when(jwsClaims.getBody()).thenReturn(claims);
         when(ltijwtService.validateState(VALID_STATE)).thenReturn(jwsClaims);
         lti3RequestMockedStatic.when(() -> LTI3Request.getInstance("https://tool.com/test")).thenReturn(lti3Request);
-        System.setOut(new PrintStream(outputStreamCaptor));
     }
 
     @AfterEach


### PR DESCRIPTION
## Description
 - Added flags to turn on/off the unimplemented services, started setting up the middleware to send the id_token to goldilocks
 - Added unit tests for lti3 controller
 - Cleaned up implementation to put "demo mode off" as primary functionality with "demo mode on" as separate endpoint

### Motivation and Context
This removes any security risk around having unused endpoints that are still reachable, and it begins the process of integrating the middleware with goldilocks by sending the LTI response to the goldilocks endpoint after completing the initial LTI Core handshake.

### Fixes
https://lumenlearning.atlassian.net/browse/L3-23

## How Has This Been Tested?
1. I set the `lti13.demoMode` value to `false` in the `application.properties` file and ensured that after clicking on a goldilocks lti link, this directed me to goldilocks and no demo UI displayed. Additionally, deep linking, AGS, and the membership service were not accessible regardless of their settings in the `application.properties` file.
2. I set the `lti13.demoMode` value to `true` and set the `lti13.enableAGS` value to `true` in the `application.properties` file and ensured that the demo UI still displayed properly and that the AGS service could be reached.


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
