### PR TITLE
L3-41 Upgrade to java 16, remove deprecated use of Integer, fix bug in demo with redirect path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <description>LTI 1.3 Java Middleware for Tools</description>
 
     <properties>
-        <java.version>8</java.version>
+        <java.version>16</java.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
@@ -95,7 +95,8 @@ public class LTI3Controller {
                 CloseableHttpResponse response = client.execute(httpPost);
                 ByteStreams.copy(response.getEntity().getContent(), res.getOutputStream());
             } else {
-                res.sendRedirect("/demo?link=" + link);
+                String redirectPath = link == null ? "/demo" : "/demo?link=" + link;
+                res.sendRedirect(redirectPath);
             }
         } catch (SignatureException ex) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid signature");

--- a/src/main/java/net/unicon/lti/utils/lti/DeepLinkUtils.java
+++ b/src/main/java/net/unicon/lti/utils/lti/DeepLinkUtils.java
@@ -260,8 +260,8 @@ public class DeepLinkUtils {
 
         Map<String, Object> iframe = new HashMap<>();
         iframe.put("src", "https://www.youtube.com/embed/corV3-WsIro");
-        iframe.put("width", new Integer("560"));
-        iframe.put("height", new Integer("315"));
+        iframe.put("width", 560);
+        iframe.put("height", 315);
         deepLink2.put("iframe", iframe);
         deepLinks.add(deepLink2);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,7 +25,7 @@ spring.thymeleaf.mode=HTML5
 ## Logging settings
 #logging.path=/var/log/lti13demo/
 logging.file=lti13demo.log
-#logging.level.ltistarter=DEBUG
+#logging.level.net.unicon=DEBUG
 #logging.level.org.springframework.web=DEBUG
 #logging.level.org.springframework.security=DEBUG
 #logging.level.org.hibernate=ERROR


### PR DESCRIPTION
## Description
Upgraded to Java 16, fixed deprecation warnings, and smoke tested to ensure nothing broke.

### Motivation and Context
This change should allow for easier Docker integration as well as higher quality, more secure code.

### Fixes
[L3-41 Java version upgrade](https://lumenlearning.atlassian.net/browse/L3-41)

## How Has This Been Tested?
1. Followed the instructions here to ensure that I was compiling/running locally using Java 16: https://codippa.com/install-openjdk16-macos/
2. Ensured that there were no new compile or run errors with the upgrade.
3. Clicked on the link to Goldilocks from the Common Cartridge and ensured that it still goes through the LTI 1.3 flow and returns the Goldilocks Error page.
4. Set the following variables to true in the application.properties file to turn the demo mode on, then went through the demo flow and ensured all output matched that of the Java 8 version.
```
lti13.demoMode=true
lti13.enableAGS=true
lti13.enableMembership=true
lti13.enableDeepLinking=true
```

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
