### PR TITLE
L3-51 fix issue where lombok led to unrecognized entities during db initialization

### DIFF
--- a/src/main/java/net/unicon/lti/controller/lti/ConfigurationController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/ConfigurationController.java
@@ -97,7 +97,7 @@ public class ConfigurationController {
         }
 
         PlatformDeployment platformDeploymentToChange = platformDeploymentSearchResult.get();
-        platformDeploymentToChange.setOAuth2TokenUrl(platformDeployment.getOAuth2TokenUrl());
+        platformDeploymentToChange.setoAuth2TokenUrl(platformDeployment.getoAuth2TokenUrl());
         platformDeploymentToChange.setClientId(platformDeployment.getClientId());
         platformDeploymentToChange.setDeploymentId(platformDeployment.getDeploymentId());
         platformDeploymentToChange.setIss(platformDeployment.getIss());

--- a/src/main/java/net/unicon/lti/model/PlatformDeployment.java
+++ b/src/main/java/net/unicon/lti/model/PlatformDeployment.java
@@ -12,8 +12,6 @@
  */
 package net.unicon.lti.model;
 
-import lombok.Data;
-
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -26,7 +24,6 @@ import javax.persistence.Table;
 import java.util.Objects;
 import java.util.Set;
 
-@Data
 @Entity
 @Table(name = "iss_configuration")
 public class PlatformDeployment extends BaseEntity {
@@ -58,6 +55,79 @@ public class PlatformDeployment extends BaseEntity {
 
     @OneToMany(mappedBy = "platformDeployment", fetch = FetchType.LAZY)
     private Set<LtiContextEntity> contexts;
+
+
+    public long getKeyId() {
+        return keyId;
+    }
+
+    public void setKeyId(long keyId) {
+        this.keyId = keyId;
+    }
+
+    public String getIss() {
+        return iss;
+    }
+
+    public void setIss(String iss) {
+        this.iss = iss;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getOidcEndpoint() {
+        return oidcEndpoint;
+    }
+
+    public void setOidcEndpoint(String oidcEndpoint) {
+        this.oidcEndpoint = oidcEndpoint;
+    }
+
+    public String getJwksEndpoint() {
+        return jwksEndpoint;
+    }
+
+    public void setJwksEndpoint(String jwksEndpoint) {
+        this.jwksEndpoint = jwksEndpoint;
+    }
+
+    public String getoAuth2TokenUrl() {
+        return oAuth2TokenUrl;
+    }
+
+    public void setoAuth2TokenUrl(String oAuth2TokenUrl) {
+        this.oAuth2TokenUrl = oAuth2TokenUrl;
+    }
+
+    public String getoAuth2TokenAud() {
+        return oAuth2TokenAud;
+    }
+
+    public void setoAuth2TokenAud(String oAuth2TokenAud) {
+        this.oAuth2TokenAud = oAuth2TokenAud;
+    }
+
+    public String getDeploymentId() {
+        return deploymentId;
+    }
+
+    public void setDeploymentId(String deploymentId) {
+        this.deploymentId = deploymentId;
+    }
+
+    public Set<LtiContextEntity> getContexts() {
+        return contexts;
+    }
+
+    public void setContexts(Set<LtiContextEntity> contexts) {
+        this.contexts = contexts;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/net/unicon/lti/service/lti/impl/AdvantageConnectorHelperImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/AdvantageConnectorHelperImpl.java
@@ -109,7 +109,7 @@ public class AdvantageConnectorHelperImpl implements AdvantageConnectorHelper {
         try {
             // We need a specific request for the token.
             HttpEntity request = createTokenRequest(scope, platformDeployment);
-            final String POST_TOKEN_URL = platformDeployment.getOAuth2TokenUrl();
+            final String POST_TOKEN_URL = platformDeployment.getoAuth2TokenUrl();
             log.debug("POST_TOKEN_URL -  " + POST_TOKEN_URL);
             reportPostResponse = postEntity(POST_TOKEN_URL, request, platformDeployment, scope);
         } catch (Exception e) {

--- a/src/main/java/net/unicon/lti/service/lti/impl/LTIJWTServiceImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/LTIJWTServiceImpl.java
@@ -136,10 +136,10 @@ public class LTIJWTServiceImpl implements LTIJWTService {
         Key toolPrivateKey = OAuthUtils.loadPrivateKey(ltiDataService.getOwnPrivateKey());
         String aud;
         //D2L needs a different aud, maybe others too
-        if (platformDeployment.getOAuth2TokenAud() != null) {
-            aud = platformDeployment.getOAuth2TokenAud();
+        if (platformDeployment.getoAuth2TokenAud() != null) {
+            aud = platformDeployment.getoAuth2TokenAud();
         } else {
-            aud = platformDeployment.getOAuth2TokenUrl();
+            aud = platformDeployment.getoAuth2TokenUrl();
         }
         String state = Jwts.builder()
                 .setHeaderParam("kid", TextConstants.DEFAULT_KID)

--- a/src/test/java/net/unicon/lti/service/lti/test/AdvantageConnectorHelperTest.java
+++ b/src/test/java/net/unicon/lti/service/lti/test/AdvantageConnectorHelperTest.java
@@ -78,7 +78,7 @@ public class AdvantageConnectorHelperTest {
     public void testGetTokenForAGSScores() {
         try {
             PlatformDeployment platformDeployment = new PlatformDeployment();
-            platformDeployment.setOAuth2TokenUrl("https://lms.com/oauth2/token");
+            platformDeployment.setoAuth2TokenUrl("https://lms.com/oauth2/token");
             when(ltijwtService.generateTokenRequestJWT(platformDeployment)).thenReturn("jwt");
             LTIToken ltiToken = new LTIToken();
             ResponseEntity<LTIToken> responseEntity = new ResponseEntity<>(ltiToken, HttpStatus.OK);
@@ -99,7 +99,7 @@ public class AdvantageConnectorHelperTest {
         try {
             Exception exception = assertThrows(ConnectionException.class, () -> {
                 PlatformDeployment platformDeployment = new PlatformDeployment();
-                platformDeployment.setOAuth2TokenUrl("https://lms.com/oauth2/token");
+                platformDeployment.setoAuth2TokenUrl("https://lms.com/oauth2/token");
                 when(ltijwtService.generateTokenRequestJWT(platformDeployment)).thenReturn("jwt");
                 LTIToken ltiToken = new LTIToken();
                 ResponseEntity<LTIToken> responseEntity = new ResponseEntity<>(ltiToken, HttpStatus.BAD_REQUEST);
@@ -121,7 +121,7 @@ public class AdvantageConnectorHelperTest {
         try {
             Exception exception = assertThrows(ConnectionException.class, () -> {
                 PlatformDeployment platformDeployment = new PlatformDeployment();
-                platformDeployment.setOAuth2TokenUrl("https://lms.com/oauth2/token");
+                platformDeployment.setoAuth2TokenUrl("https://lms.com/oauth2/token");
                 when(ltijwtService.generateTokenRequestJWT(platformDeployment)).thenReturn("jwt");
                 when(restTemplate.postForEntity(anyString(), any(HttpEntity.class), eq(LTIToken.class))).thenReturn(null);
 
@@ -141,7 +141,7 @@ public class AdvantageConnectorHelperTest {
         try {
             assertThrows(ConnectionException.class, () -> {
                 PlatformDeployment platformDeployment = new PlatformDeployment();
-                platformDeployment.setOAuth2TokenUrl("https://lms.com/oauth2/token");
+                platformDeployment.setoAuth2TokenUrl("https://lms.com/oauth2/token");
                 when(ltijwtService.generateTokenRequestJWT(platformDeployment)).thenThrow(GeneralSecurityException.class);
 
                 advantageConnectorHelper.getToken(platformDeployment, AGSScope.AGS_SCORES_SCOPE.getScope());


### PR DESCRIPTION
## Description
An issue was caused by adding the lombok annotation to the PlatformDeployment class as this changed the expected names of the db table columns. This change has been undone to allow for the database to get initialized in AWS.

### Motivation and Context
This change was required to allow for the database to get seeded in AWS.

### Fixes
[L3-51 Fix issue of unrecognized entities for initial db setup](https://lumenlearning.atlassian.net/browse/L3-51)

## How Has This Been Tested?
1. Followed the instructions in the README.md file to create a new db.
2. Compiled/build the code and noted that the `iss_configuration` db table (the db table corresponding to the PlatformDeployment class) had the expected columns present.

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
