### PR TITLE
L3-64 Add more specific logging for GPB

### DIFF
--- a/src/main/java/net/unicon/lti/repository/LtiContextRepository.java
+++ b/src/main/java/net/unicon/lti/repository/LtiContextRepository.java
@@ -31,5 +31,7 @@ public interface LtiContextRepository extends JpaRepository<LtiContextEntity, Lo
 
     List<LtiContextEntity> findByPlatformDeployment(PlatformDeployment platformDeployment);
 
+    LtiContextEntity findByLineitems(String lineitems);
+
     int deleteByContextKeyAndPlatformDeployment(String contextKey, PlatformDeployment platformDeployment);
 }

--- a/src/main/java/net/unicon/lti/service/lti/impl/AdvantageAGSServiceImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/AdvantageAGSServiceImpl.java
@@ -321,8 +321,7 @@ public class AdvantageAGSServiceImpl implements AdvantageAGSService {
     }
 
     @Override
-    public ResponseEntity<Void> postScore(LTIToken lTITokenScores, String lineItemId, Score score) throws ConnectionException {
-        try {
+    public ResponseEntity<Void> postScore(LTIToken lTITokenScores, String lineItemId, Score score) {
             log.debug(TextConstants.TOKEN + lTITokenScores.getAccess_token());
             RestTemplate restTemplate = advantageConnectorHelper.createRestTemplate();
 
@@ -333,12 +332,6 @@ public class AdvantageAGSServiceImpl implements AdvantageAGSService {
             log.debug("POST_SCORES -  " + POST_SCORES);
             ResponseEntity<Void> postScoreResponse = restTemplate.exchange(POST_SCORES, HttpMethod.POST, request, Void.class);
             return postScoreResponse;
-        } catch (Exception e) {
-            StringBuilder exceptionMsg = new StringBuilder();
-            exceptionMsg.append("Can't post scores");
-            log.error(exceptionMsg.toString(), e);
-            throw new ConnectionException(exceptionMessageGenerator.exceptionMessage(exceptionMsg.toString(), e));
-        }
     }
 
     @Override

--- a/src/main/java/net/unicon/lti/service/sqs/impl/SQSMessageReceiver.java
+++ b/src/main/java/net/unicon/lti/service/sqs/impl/SQSMessageReceiver.java
@@ -108,7 +108,6 @@ public class SQSMessageReceiver {
             newTimeout = newTimeout < 0 || newTimeout > 43199 ? 43199 : newTimeout;
             visibility.extend(newTimeout);
 
-            log.error(ex.toString());
             log.error("Score failed to post to LMS: {}", sqsLineItemJson);
             String lineItemsUrl = lineItemUrlToLineItemsUrl(lineItemUrl);
             LtiContextEntity course = ltiContextRepository.findByLineitems(lineItemsUrl);

--- a/src/main/java/net/unicon/lti/service/sqs/impl/SQSMessageReceiver.java
+++ b/src/main/java/net/unicon/lti/service/sqs/impl/SQSMessageReceiver.java
@@ -6,10 +6,12 @@ import lombok.extern.slf4j.Slf4j;
 import net.unicon.lti.exceptions.BadTokenException;
 import net.unicon.lti.exceptions.ConnectionException;
 import net.unicon.lti.exceptions.DataServiceException;
+import net.unicon.lti.model.LtiContextEntity;
 import net.unicon.lti.model.PlatformDeployment;
 import net.unicon.lti.model.ags.Score;
 import net.unicon.lti.model.oauth2.LTIToken;
 import net.unicon.lti.model.sqs.SQSLineItem;
+import net.unicon.lti.repository.LtiContextRepository;
 import net.unicon.lti.repository.PlatformDeploymentRepository;
 import net.unicon.lti.service.lti.AdvantageAGSService;
 import net.unicon.lti.utils.AGSScope;
@@ -26,13 +28,20 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Locale;
 
 @Slf4j
 @Service
 @NoArgsConstructor
 public class SQSMessageReceiver {
+    private static final String END_OF_LINEITEMS_URL_LOWER_CASE = "lineitems";
+    private static final String END_OF_LINEITEMS_URL_LOWER_CASE_CANVAS = "line_items";
+
     @Autowired
     PlatformDeploymentRepository platformDeploymentRepository;
+
+    @Autowired
+    LtiContextRepository ltiContextRepository;
 
     @Autowired
     AdvantageAGSService advantageAGSServiceImpl;
@@ -46,18 +55,24 @@ public class SQSMessageReceiver {
     ) {
         log.debug("message received {}", sqsLineItemJson);
         log.debug("Current time in millis: {}", System.currentTimeMillis());
+        String lineItemUrl = "";
 
         try {
             ObjectMapper objectMapper = new ObjectMapper();
             SQSLineItem sqsLineItem = objectMapper.readValue(sqsLineItemJson, SQSLineItem.class);
 
+            // Save lineitem url for logging
+            lineItemUrl = sqsLineItem.getLineItemUrl();
+
+            // Validation
             if (sqsLineItem.getScore() < 0 || sqsLineItem.getScore() > 1) {
                 throw new IllegalArgumentException("Score given for this line item must be between 0.0 and 1.0, and it is " + sqsLineItem.getScore());
             }
 
+            // Convert from SQS to IMS AGS format
             Score score = sqsLineItem.toScore();
 
-            // get the deployment authorized to post scores
+            // get the registration/deployment authorized to post scores
             List<PlatformDeployment> platformDeployment = platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(
                     sqsLineItem.getIssuer(),
                     sqsLineItem.getClientId(),
@@ -77,22 +92,68 @@ public class SQSMessageReceiver {
                     if (status.is2xxSuccessful()) {
                         acknowledgment.acknowledge(); // Remove message from queue upon success
                     } else {
+                        log.error("Response Status: {}: {}", status.value(), status.name());
+                        log.error("Response Status Reason: {}", status.getReasonPhrase());
+                        log.error("Response Body: {}", response.getBody());
                         throw new ConnectionException("Can't post score");
                     }
                 } else {
                     throw new BadTokenException("No authorization token for permission to post score.");
                 }
             } else {
-                throw new DataServiceException("No deployment to retrieve authorization token for permission to post score.");
+                throw new DataServiceException("No registration/deployment to retrieve authorization token for permission to post score.");
             }
         } catch (Exception ex) {
             int newTimeout = (int) Math.pow(2,receiveCount - 1) * 30;
             newTimeout = newTimeout < 0 || newTimeout > 43199 ? 43199 : newTimeout;
             visibility.extend(newTimeout);
+
+            log.error(ex.toString());
             log.error("Score failed to post to LMS: {}", sqsLineItemJson);
+            String lineItemsUrl = lineItemUrlToLineItemsUrl(lineItemUrl);
+            LtiContextEntity course = ltiContextRepository.findByLineitems(lineItemsUrl);
+            if (course != null) {
+                log.error("LTI Middleware Course ID: {}", course.getContextId());
+                log.error("LMS Course/Context ID: {}", course.getContextKey());
+                log.error("Course/Context Title: {}", course.getTitle());
+            } else {
+                log.error("Context/Course Was Not Found");
+            }
             log.error("This score has been received from SQS {} times.", receiveCount);
             log.debug("New visibility timeout: {}", newTimeout);
             ex.printStackTrace();
+        }
+    }
+
+    private String lineItemUrlToLineItemsUrl(String lineitemUrl) {
+        /*
+        Moodle AGS Format:
+            lineitems=http://localhost:8000/mod/lti/services.php/3/lineitems?type_id=14
+            lineitem=http://localhost:8000/mod/lti/services.php/3/lineitems/6/lineitem?type_id=14
+        Blackboard AGS Format (from https://docs.blackboard.com/lti/core/id-token):
+            lineitems=https://example.com/learn/api/v1/lti/courses/_122_1/lineItems
+            lineitem=https://example.com/learn/api/v1/lti/courses/_122_1/lineItems/_7454_1
+        Canvas AGS Format:
+            lineitems=https://test.instructure.com/api/lti/courses/3348/line_items
+            lineitem=https://test.instructure.com/api/lti/courses/3348/line_items/503
+        D2l/Brightspace AGS Format (from https://documentation.brightspace.com/EN/integrations/ipsis/LTI%20Advantage/lti_1.3_assignments_grade_services.htm):
+            lineitems=https://test.brightspace.com/d2l/api/lti/ags/2.0/deployment/a748e0da-6cd3-4f8d-acf3-73f2e11457c9/orgunit/6836/lineitems
+            lineitem=https://test.brightspace.com/d2l/api/lti/ags/2.0/deployment/a748e0da-6cd3-4f8d-acf3-73f2e11457c9/orgunit/6836/lineitems/1
+        */
+
+        try {
+            String lowerCaseLineitemUrl = lineitemUrl.toLowerCase(Locale.ROOT);
+            boolean isCanvasFormat = lowerCaseLineitemUrl.indexOf(END_OF_LINEITEMS_URL_LOWER_CASE_CANVAS) > 0;
+            int endIdx = isCanvasFormat ? lowerCaseLineitemUrl.indexOf(END_OF_LINEITEMS_URL_LOWER_CASE_CANVAS) + END_OF_LINEITEMS_URL_LOWER_CASE_CANVAS.length() :
+                    lowerCaseLineitemUrl.indexOf(END_OF_LINEITEMS_URL_LOWER_CASE) + END_OF_LINEITEMS_URL_LOWER_CASE.length();
+            String atEndIdxPlusLineitems = lineitemUrl.substring(0, endIdx);
+            String params = lineitemUrl.indexOf("?") > 0 ? lineitemUrl.substring(lineitemUrl.indexOf("?")) : "";
+            log.debug("Calculated lineitems Url: {}", atEndIdxPlusLineitems + params);
+            return atEndIdxPlusLineitems + params;
+        } catch (Exception e) {
+            log.error("Unable to calculate lineItems URL to find course because");
+            log.error(e.toString());
+            return "";
         }
     }
 }

--- a/src/test/java/net/unicon/lti/service/lti/test/AdvantageAGSServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/lti/test/AdvantageAGSServiceTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -79,14 +80,14 @@ public class AdvantageAGSServiceTest {
         when(advantageConnectorHelper.createTokenizedRequestEntity(ltiToken, score)).thenReturn(httpEntity);
         when(restTemplate.exchange(anyString(), eq(HttpMethod.POST), eq(httpEntity), eq(Void.class))).thenThrow(RestClientException.class);
 
-        assertThrows(ConnectionException.class, () -> {
+        assertThrows(RestClientException.class, () -> {
             advantageAGSService.postScore(ltiToken, "https://lms.com/line_item/456", score);
         });
 
         verify(advantageConnectorHelper).createRestTemplate();
         verify(advantageConnectorHelper).createTokenizedRequestEntity(ltiToken, score);
         verify(restTemplate).exchange(anyString(), eq(HttpMethod.POST), eq(httpEntity), eq(Void.class));
-        verify(exceptionMessageGenerator).exceptionMessage(eq("Can't post scores"), any(Exception.class));
+        verify(exceptionMessageGenerator, never()).exceptionMessage(any(String.class), any(Exception.class));
     }
 
 }

--- a/src/test/java/net/unicon/lti/service/sqs/test/SQSMessageReceiverTest.java
+++ b/src/test/java/net/unicon/lti/service/sqs/test/SQSMessageReceiverTest.java
@@ -4,6 +4,7 @@ import net.unicon.lti.exceptions.ConnectionException;
 import net.unicon.lti.model.PlatformDeployment;
 import net.unicon.lti.model.ags.Score;
 import net.unicon.lti.model.oauth2.LTIToken;
+import net.unicon.lti.repository.LtiContextRepository;
 import net.unicon.lti.repository.PlatformDeploymentRepository;
 import net.unicon.lti.service.lti.AdvantageAGSService;
 import net.unicon.lti.service.sqs.impl.SQSMessageReceiver;
@@ -39,6 +40,9 @@ public class SQSMessageReceiverTest {
     private PlatformDeploymentRepository platformDeploymentRepository;
 
     @Mock
+    private LtiContextRepository ltiContextRepository;
+
+    @Mock
     private AdvantageAGSService advantageAGSService;
 
     @Mock
@@ -61,6 +65,7 @@ public class SQSMessageReceiverTest {
             verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString());
             verify(advantageAGSService, never()).getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class));
             verify(advantageAGSService, never()).postScore(any(LTIToken.class), anyString(), any(Score.class));
+            verify(ltiContextRepository).findByLineitems(eq(""));
             verify(acknowledgment, never()).acknowledge();
             verify(visibility, times(1)).extend(30);
         } catch (ConnectionException e) {
@@ -77,6 +82,7 @@ public class SQSMessageReceiverTest {
             verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString());
             verify(advantageAGSService, never()).getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class));
             verify(advantageAGSService, never()).postScore(any(LTIToken.class), anyString(), any(Score.class));
+            verify(ltiContextRepository).findByLineitems(eq(""));
             verify(acknowledgment, never()).acknowledge();
             verify(visibility, times(1)).extend(30);
         } catch (ConnectionException e) {
@@ -93,6 +99,7 @@ public class SQSMessageReceiverTest {
             verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString());
             verify(advantageAGSService, never()).getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class));
             verify(advantageAGSService, never()).postScore(any(LTIToken.class), anyString(), any(Score.class));
+            verify(ltiContextRepository).findByLineitems(eq(""));
             verify(acknowledgment, never()).acknowledge();
             verify(visibility, times(1)).extend(30);
         } catch (ConnectionException e) {
@@ -109,6 +116,7 @@ public class SQSMessageReceiverTest {
             verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString());
             verify(advantageAGSService, never()).getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class));
             verify(advantageAGSService, never()).postScore(any(LTIToken.class), anyString(), any(Score.class));
+            verify(ltiContextRepository).findByLineitems(eq(""));
             verify(acknowledgment, never()).acknowledge();
             verify(visibility, times(1)).extend(30);
         } catch (ConnectionException e) {
@@ -125,6 +133,7 @@ public class SQSMessageReceiverTest {
             verify(platformDeploymentRepository, times(1)).findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString());
             verify(advantageAGSService, never()).getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class));
             verify(advantageAGSService, never()).postScore(any(LTIToken.class), anyString(), any(Score.class));
+            verify(ltiContextRepository).findByLineitems(eq(""));
             verify(acknowledgment, never()).acknowledge();
             verify(visibility, times(1)).extend(30);
         } catch (ConnectionException e) {
@@ -144,6 +153,7 @@ public class SQSMessageReceiverTest {
             verify(platformDeploymentRepository, times(1)).findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString());
             verify(advantageAGSService, times(1)).getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class));
             verify(advantageAGSService, never()).postScore(any(LTIToken.class), anyString(), any(Score.class));
+            verify(ltiContextRepository).findByLineitems(eq(""));
             verify(acknowledgment, never()).acknowledge();
             verify(visibility, times(1)).extend(30);
         } catch (ConnectionException e) {
@@ -168,6 +178,107 @@ public class SQSMessageReceiverTest {
             verify(platformDeploymentRepository, times(1)).findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString());
             verify(advantageAGSService, times(1)).getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class));
             verify(advantageAGSService, times(1)).postScore(any(LTIToken.class), anyString(), any(Score.class));
+            verify(ltiContextRepository).findByLineitems(eq(""));
+            verify(acknowledgment, never()).acknowledge();
+            verify(visibility, times(1)).extend(30);
+        } catch (ConnectionException e) {
+            fail("Exception should not be thrown.");
+        }
+    }
+
+    @Test
+    public void testReceiveMessagePostScoreFailureWithMoodleLineitemUrlFormat() {
+        try {
+            String sqsLineItemJson = "{\"client_id\": \"test1\", \"user_id\": \"test2\", \"deployment_id\": \"test3\", \"issuer\": \"test4\", \"line_item_url\": \"http://localhost:8000/mod/lti/services.php/3/lineitems/6/lineitem?type_id=14\", \"score\": 0.8}";
+            PlatformDeployment platformDeployment = new PlatformDeployment();
+            List<PlatformDeployment> platformDeploymentList = Collections.singletonList(platformDeployment);
+            when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString())).thenReturn(platformDeploymentList);
+            LTIToken ltiToken = new LTIToken();
+            ltiToken.setAccess_token("test-token");
+            when(advantageAGSService.getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class))).thenReturn(ltiToken);
+            ResponseEntity<Void> response = new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+            when(advantageAGSService.postScore(any(LTIToken.class), anyString(), any(Score.class))).thenReturn(response);
+
+            sqsMessageReceiver.receiveMessage(sqsLineItemJson, 1, visibility, acknowledgment);
+            verify(platformDeploymentRepository, times(1)).findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString());
+            verify(advantageAGSService, times(1)).getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class));
+            verify(advantageAGSService, times(1)).postScore(any(LTIToken.class), anyString(), any(Score.class));
+            verify(ltiContextRepository).findByLineitems(eq("http://localhost:8000/mod/lti/services.php/3/lineitems?type_id=14"));
+            verify(acknowledgment, never()).acknowledge();
+            verify(visibility, times(1)).extend(30);
+        } catch (ConnectionException e) {
+            fail("Exception should not be thrown.");
+        }
+    }
+
+    @Test
+    public void testReceiveMessagePostScoreFailureWithBlackboardLineitemUrlFormat() {
+        try {
+            String sqsLineItemJson = "{\"client_id\": \"test1\", \"user_id\": \"test2\", \"deployment_id\": \"test3\", \"issuer\": \"test4\", \"line_item_url\": \"https://example.com/learn/api/v1/lti/courses/_122_1/lineItems/_7454_1\", \"score\": 0.8}";
+            PlatformDeployment platformDeployment = new PlatformDeployment();
+            List<PlatformDeployment> platformDeploymentList = Collections.singletonList(platformDeployment);
+            when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString())).thenReturn(platformDeploymentList);
+            LTIToken ltiToken = new LTIToken();
+            ltiToken.setAccess_token("test-token");
+            when(advantageAGSService.getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class))).thenReturn(ltiToken);
+            ResponseEntity<Void> response = new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+            when(advantageAGSService.postScore(any(LTIToken.class), anyString(), any(Score.class))).thenReturn(response);
+
+            sqsMessageReceiver.receiveMessage(sqsLineItemJson, 1, visibility, acknowledgment);
+            verify(platformDeploymentRepository, times(1)).findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString());
+            verify(advantageAGSService, times(1)).getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class));
+            verify(advantageAGSService, times(1)).postScore(any(LTIToken.class), anyString(), any(Score.class));
+            verify(ltiContextRepository).findByLineitems(eq("https://example.com/learn/api/v1/lti/courses/_122_1/lineItems"));
+            verify(acknowledgment, never()).acknowledge();
+            verify(visibility, times(1)).extend(30);
+        } catch (ConnectionException e) {
+            fail("Exception should not be thrown.");
+        }
+    }
+
+    @Test
+    public void testReceiveMessagePostScoreFailureWithCanvasLineitemUrlFormat() {
+        try {
+            String sqsLineItemJson = "{\"client_id\": \"test1\", \"user_id\": \"test2\", \"deployment_id\": \"test3\", \"issuer\": \"test4\", \"line_item_url\": \"https://test.instructure.com/api/lti/courses/3348/line_items/503\", \"score\": 0.8}";
+            PlatformDeployment platformDeployment = new PlatformDeployment();
+            List<PlatformDeployment> platformDeploymentList = Collections.singletonList(platformDeployment);
+            when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString())).thenReturn(platformDeploymentList);
+            LTIToken ltiToken = new LTIToken();
+            ltiToken.setAccess_token("test-token");
+            when(advantageAGSService.getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class))).thenReturn(ltiToken);
+            ResponseEntity<Void> response = new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+            when(advantageAGSService.postScore(any(LTIToken.class), anyString(), any(Score.class))).thenReturn(response);
+
+            sqsMessageReceiver.receiveMessage(sqsLineItemJson, 1, visibility, acknowledgment);
+            verify(platformDeploymentRepository, times(1)).findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString());
+            verify(advantageAGSService, times(1)).getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class));
+            verify(advantageAGSService, times(1)).postScore(any(LTIToken.class), anyString(), any(Score.class));
+            verify(ltiContextRepository).findByLineitems(eq("https://test.instructure.com/api/lti/courses/3348/line_items"));
+            verify(acknowledgment, never()).acknowledge();
+            verify(visibility, times(1)).extend(30);
+        } catch (ConnectionException e) {
+            fail("Exception should not be thrown.");
+        }
+    }
+
+    @Test
+    public void testReceiveMessagePostScoreFailureWithD2LBrightspaceLineitemUrlFormat() {
+        try {
+            String sqsLineItemJson = "{\"client_id\": \"test1\", \"user_id\": \"test2\", \"deployment_id\": \"test3\", \"issuer\": \"test4\", \"line_item_url\": \"https://test.brightspace.com/d2l/api/lti/ags/2.0/deployment/a748e0da-6cd3-4f8d-acf3-73f2e11457c9/orgunit/6836/lineitems/1\", \"score\": 0.8}";
+            PlatformDeployment platformDeployment = new PlatformDeployment();
+            List<PlatformDeployment> platformDeploymentList = Collections.singletonList(platformDeployment);
+            when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString())).thenReturn(platformDeploymentList);
+            LTIToken ltiToken = new LTIToken();
+            ltiToken.setAccess_token("test-token");
+            when(advantageAGSService.getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class))).thenReturn(ltiToken);
+            ResponseEntity<Void> response = new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+            when(advantageAGSService.postScore(any(LTIToken.class), anyString(), any(Score.class))).thenReturn(response);
+
+            sqsMessageReceiver.receiveMessage(sqsLineItemJson, 1, visibility, acknowledgment);
+            verify(platformDeploymentRepository, times(1)).findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString());
+            verify(advantageAGSService, times(1)).getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class));
+            verify(advantageAGSService, times(1)).postScore(any(LTIToken.class), anyString(), any(Score.class));
+            verify(ltiContextRepository).findByLineitems(eq("https://test.brightspace.com/d2l/api/lti/ags/2.0/deployment/a748e0da-6cd3-4f8d-acf3-73f2e11457c9/orgunit/6836/lineitems"));
             verify(acknowledgment, never()).acknowledge();
             verify(visibility, times(1)).extend(30);
         } catch (ConnectionException e) {
@@ -192,6 +303,7 @@ public class SQSMessageReceiverTest {
             verify(platformDeploymentRepository, times(1)).findByIssAndClientIdAndDeploymentId(anyString(), anyString(), anyString());
             verify(advantageAGSService, times(1)).getToken(eq(AGSScope.AGS_SCORES_SCOPE), any(PlatformDeployment.class));
             verify(advantageAGSService, times(1)).postScore(any(LTIToken.class), anyString(), any(Score.class));
+            verify(ltiContextRepository, never()).findByLineitems(any(String.class));
             verify(acknowledgment, times(1)).acknowledge();
             verify(visibility, never()).extend(30);
         } catch (ConnectionException e) {


### PR DESCRIPTION
## Description
In the event that a score fails posting to the LMS with a non-2xx-successful status and an exception isn't thrown, the following lines will appear in the logs:
```
2022-01-10 10:19:44.268 ERROR 8859 --- [enerContainer-2] n.u.l.s.sqs.impl.SQSMessageReceiver      : Response Status: <value>: <name>
2022-01-10 10:19:44.268 ERROR 8859 --- [enerContainer-2] n.u.l.s.sqs.impl.SQSMessageReceiver      : Response Status Reason: <reason>
2022-01-10 10:19:44.268 ERROR 8859 --- [enerContainer-2] n.u.l.s.sqs.impl.SQSMessageReceiver      : Response Body: <body>
```

After failing to post the score for any reason, lines similar to the following will appear in the logs:
```
2022-01-11 13:02:25.824 ERROR 51419 --- [enerContainer-2] n.u.l.s.sqs.impl.SQSMessageReceiver      : Score failed to post to LMS: {"client_id": "97140000000000230", "user_id": "4f3d12df-e1ae-484f-8b9a-b667864e8100", "deployment_id": "461:5440a08422ab1ee7794a0588b5e4cb4a094c4256", "issuer": "https://canvas.instructure.com", "line_item_url": "https://unicon.instructure.com/api/lti/courses/493/line_items", "score": 0.3}
2022-01-11 13:02:25.826 ERROR 51419 --- [enerContainer-2] n.u.l.s.sqs.impl.SQSMessageReceiver      : LTI Middleware Course ID: 1
2022-01-11 13:02:25.827 ERROR 51419 --- [enerContainer-2] n.u.l.s.sqs.impl.SQSMessageReceiver      : LMS Course/Context ID: fc2a404eb365d832a59dcea00f11b282750658d4
2022-01-11 13:02:25.827 ERROR 51419 --- [enerContainer-2] n.u.l.s.sqs.impl.SQSMessageReceiver      : Course/Context Title: Alexa Biology
2022-01-11 13:02:25.827 ERROR 51419 --- [enerContainer-2] n.u.l.s.sqs.impl.SQSMessageReceiver      : This score has been received from SQS 10 times.
org.springframework.web.client.HttpClientErrorException$UnprocessableEntity: 422 Unprocessable Entity: "<!DOCTYPE html><EOL><html class="scripts-not-loaded" dir="ltr"   lang="en"><EOL><head><EOL>  <meta charset="utf-8"><EOL>...
```

### Motivation and Context
This adjustment was made so that it can be easier to identify the root cause when scores fail to post.

### Fixes
[L3-64](https://lumenlearning.atlassian.net/browse/L3-64)

## How Has This Been Tested?
1. An SQS queue was created and hooked into the middleware for testing in the `application.properties` file and `logging.level.net.unicon` was uncommented and given a value of `ERROR`.
2. The following JSON was sent to the SQS queue to simulate a successful grade posting: `{"client_id": "97140000000000230", "user_id": "4f3d12df-e1ae-484f-8b9a-b667864e8100", "deployment_id": "461:5440a08422ab1ee7794a0588b5e4cb4a094c4256", "issuer": "https://canvas.instructure.com", "line_item_url": "https://unicon.instructure.com/api/lti/courses/3348/line_items/503", "score": 0.9}`
3. When clicking on the Gradebook in Canvas a score of 4.5/5.0 (90%) can be seen for this lineitem and nothing appeared in the logs.
4. The following JSON was sent to the SQS queue to simulate a 422 Unprocessable Entity failure: `{"client_id": "97140000000000230", "user_id": "4f3d12df-e1ae-484f-8b9a-b667864e8100", "deployment_id": "461:5440a08422ab1ee7794a0588b5e4cb4a094c4256", "issuer": "https://canvas.instructure.com", "line_item_url": "https://unicon.instructure.com/api/lti/courses/3348/line_items", "score": 0.9}` (lineitems url used instead of lineitem url)
5. No grade appeared in the gradebook and the following appeared in the logs:
```
2022-01-11 13:02:25.824 ERROR 51419 --- [enerContainer-2] n.u.l.s.sqs.impl.SQSMessageReceiver      : Score failed to post to LMS: {"client_id": "97140000000000230", "user_id": "4f3d12df-e1ae-484f-8b9a-b667864e8100", "deployment_id": "461:5440a08422ab1ee7794a0588b5e4cb4a094c4256", "issuer": "https://canvas.instructure.com", "line_item_url": "https://unicon.instructure.com/api/lti/courses/493/line_items", "score": 0.3}
2022-01-11 13:02:25.826 ERROR 51419 --- [enerContainer-2] n.u.l.s.sqs.impl.SQSMessageReceiver      : LTI Middleware Course ID: 1
2022-01-11 13:02:25.827 ERROR 51419 --- [enerContainer-2] n.u.l.s.sqs.impl.SQSMessageReceiver      : LMS Course/Context ID: fc2a404eb365d832a59dcea00f11b282750658d4
2022-01-11 13:02:25.827 ERROR 51419 --- [enerContainer-2] n.u.l.s.sqs.impl.SQSMessageReceiver      : Course/Context Title: Alexa Biology
2022-01-11 13:02:25.827 ERROR 51419 --- [enerContainer-2] n.u.l.s.sqs.impl.SQSMessageReceiver      : This score has been received from SQS 10 times.
org.springframework.web.client.HttpClientErrorException$UnprocessableEntity: 422 Unprocessable Entity: "<!DOCTYPE html><EOL><html class="scripts-not-loaded" dir="ltr"   lang="en"><EOL><head><EOL>  <meta charset="utf-8"><EOL>...
```
6. The following JSON was sent to the SQS queue to simulate a 400 Bad Request from not being able to retrieve a token from a local Moodle instance: `{"client_id": "JQIMHkxNkFhlvBl", "user_id": "2", "deployment_id": "14", "issuer": "http://localhost:8000", "line_item_url": "http://localhost:8000/mod/lti/services.php/3/lineitems/6/lineitem?type_id=14", "score": 0.3}`
7. The following appeared in the logs:
```
2022-01-11 13:01:10.252 ERROR 51419 --- [enerContainer-3] n.u.l.s.l.i.AdvantageConnectorHelperImpl : Can't get the token. Exception
2022-01-11 13:01:10.252 ERROR 51419 --- [enerContainer-3] n.u.l.s.sqs.impl.SQSMessageReceiver      : net.unicon.lti.exceptions.ConnectionException: Can't get the token. Exception
Exception : 400 Bad Request: "{<EOL>  "error" : "invalid_request"<EOL>}"
2022-01-11 13:01:10.252 ERROR 51419 --- [enerContainer-3] n.u.l.s.sqs.impl.SQSMessageReceiver      : Score failed to post to LMS: {"client_id": "JQIMHkxNkFhlvBl", "user_id": "2", "deployment_id": "14", "issuer": "http://localhost:8000", "line_item_url": "http://localhost:8000/mod/lti/services.php/3/lineitems/6/lineitem?type_id=14", "score": 0.3}
2022-01-11 13:01:10.254 ERROR 51419 --- [enerContainer-3] n.u.l.s.sqs.impl.SQSMessageReceiver      : LTI Middleware Course ID: 11
2022-01-11 13:01:10.254 ERROR 51419 --- [enerContainer-3] n.u.l.s.sqs.impl.SQSMessageReceiver      : LMS Course/Context ID: 3
2022-01-11 13:01:10.254 ERROR 51419 --- [enerContainer-3] n.u.l.s.sqs.impl.SQSMessageReceiver      : Course/Context Title: Lumen Abnormal Psychology
2022-01-11 13:01:10.254 ERROR 51419 --- [enerContainer-3] n.u.l.s.sqs.impl.SQSMessageReceiver      : This score has been received from SQS 8 times.
net.unicon.lti.exceptions.ConnectionException: Can't get the token. Exception
Exception : 400 Bad Request: "{<EOL>  "error" : "invalid_request"<EOL>}"
	at net.unicon.lti.service.lti.impl.AdvantageConnectorHelperImpl.getToken(AdvantageConnectorHelperImpl.java:120)

```
8. The following JSON was sent to the SQS queue to simulate a Connection Timed Out failure: `{"client_id": "97140000000000230", "user_id": "4f3d12df-e1ae-484f-8b9a-b667864e8100", "deployment_id": "461:5440a08422ab1ee7794a0588b5e4cb4a094c4256", "issuer": "https://canvas.instructure.com", "line_item_url": "https://unicon.test.com/api/lti/courses/3348/line_items/503", "score": 0.2}` ("instructure" was replaced with "test" in the lineitem url)
9. The following appeared in the logs:
```
2022-01-11 13:03:41.430 ERROR 51419 --- [enerContainer-5] n.u.l.s.sqs.impl.SQSMessageReceiver      : Score failed to post to LMS: {"client_id": "97140000000000230", "user_id": "4f3d12df-e1ae-484f-8b9a-b667864e8100", "deployment_id": "461:5440a08422ab1ee7794a0588b5e4cb4a094c4256", "issuer": "https://canvas.instructure.com", "line_item_url": "https://unicon.test.com/api/lti/courses/3348/line_items/503", "score": 0.2}
2022-01-11 13:03:41.433 ERROR 51419 --- [enerContainer-5] n.u.l.s.sqs.impl.SQSMessageReceiver      : Context/Course Was Not Found
2022-01-11 13:03:41.433 ERROR 51419 --- [enerContainer-5] n.u.l.s.sqs.impl.SQSMessageReceiver      : This score has been received from SQS 8 times.
org.springframework.web.client.ResourceAccessException: I/O error on POST request for "https://unicon.test.com/api/lti/courses/3348/line_items/503/scores": Operation timed out; nested exception is java.net.ConnectException: Operation timed out
	at org.springframework.web.client.RestTemplate.doExecute(RestTemplate.java:785)
	at org.springframework.web.client.RestTemplate.execute(RestTemplate.java:711)
	at org.springframework.web.client.RestTemplate.exchange(RestTemplate.java:602)
	at net.unicon.lti.service.lti.impl.AdvantageAGSServiceImpl.postScore(AdvantageAGSServiceImpl.java:333)
```
---

## ⚠️ Deployment instructions ⚠️
Ensure that the logging level is set to ERROR. In a local environment, this is done by uncommenting the `logging.level.net.unicon` property and giving it a value of `ERROR` in the `application.properties` file.

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
