### PR TITLE
L3-63 Change format of lineitem url field for SQS message to AGS for posting grades

### DIFF
--- a/src/main/java/net/unicon/lti/model/sqs/SQSLineItem.java
+++ b/src/main/java/net/unicon/lti/model/sqs/SQSLineItem.java
@@ -22,8 +22,8 @@ public class SQSLineItem {
 
     private String issuer;
 
-    @JsonProperty("line_item_url")
-    private String lineItemUrl;
+    @JsonProperty("lineitem_url")
+    private String lineitemUrl;
 
     private float score; // between 0.0 - 1.0
 

--- a/src/main/java/net/unicon/lti/service/sqs/impl/SQSMessageReceiver.java
+++ b/src/main/java/net/unicon/lti/service/sqs/impl/SQSMessageReceiver.java
@@ -62,7 +62,7 @@ public class SQSMessageReceiver {
             SQSLineItem sqsLineItem = objectMapper.readValue(sqsLineItemJson, SQSLineItem.class);
 
             // Save lineitem url for logging
-            lineItemUrl = sqsLineItem.getLineItemUrl();
+            lineItemUrl = sqsLineItem.getLineitemUrl();
 
             // Validation
             if (sqsLineItem.getScore() < 0 || sqsLineItem.getScore() > 1) {
@@ -86,7 +86,7 @@ public class SQSMessageReceiver {
                 // 2. Post score
                 if (scoresToken != null && !StringUtils.isEmpty(scoresToken.getAccess_token())) {
                     log.debug(TextConstants.TOKEN + scoresToken.getAccess_token());
-                    ResponseEntity<Void> response = advantageAGSServiceImpl.postScore(scoresToken, sqsLineItem.getLineItemUrl(), score);
+                    ResponseEntity<Void> response = advantageAGSServiceImpl.postScore(scoresToken, sqsLineItem.getLineitemUrl(), score);
                     HttpStatus status = response.getStatusCode();
                     log.debug(status.name());
                     if (status.is2xxSuccessful()) {


### PR DESCRIPTION
## Description
In the JSON input to the SQS queue for posting grades with the middleware, the `line_item_url` field has been changed to be the `lineitem_url` field.

### Motivation and Context
This change leads to more consistency between the middleware, Goldilocks, and the IMS specifcation.

### Fixes
[L3-63](https://lumenlearning.atlassian.net/browse/L3-63)

## How Has This Been Tested?
1. Ensure that an SQS queue has been setup and hooked up to the middleware. Also ensure that the middleware has been registered with the Canvas instance/course that will be used for testing.
2. Send a message to the SQS queue with the following JSON format: `{"client_id": "97140000000000230", "user_id": "4f3d12df-e1ae-484f-8b9a-b667864e8100", "deployment_id": "461:5440a08422ab1ee7794a0588b5e4cb4a094c4256", "issuer": "https://canvas.instructure.com", "line_item_url": "https://unicon.instructure.com/api/lti/courses/3348/line_items/503", "score": 0.3}`
3. Note that the grade was not posted to Canvas and that there is an error in the logs indicating `UnrecognizedPropertyException: Unrecognized field "line_item_url"`
4. Send a message to the SQS queue with the following JSON format: `{"client_id": "97140000000000230", "user_id": "4f3d12df-e1ae-484f-8b9a-b667864e8100", "deployment_id": "461:5440a08422ab1ee7794a0588b5e4cb4a094c4256", "issuer": "https://canvas.instructure.com", "lineitem_url": "https://unicon.instructure.com/api/lti/courses/3348/line_items/503", "score": 0.3}`
5. Note that the grade was posted to Canvas and that there are no errors in the logs.

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
