### PR TITLE
L3-74 remove platformDeployment context from JSON output, add pagination to GET config endpoint

### DIFF
--- a/src/main/java/net/unicon/lti/controller/lti/ConfigurationController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/ConfigurationController.java
@@ -18,6 +18,8 @@ import net.unicon.lti.repository.PlatformDeploymentRepository;
 import net.unicon.lti.utils.TextConstants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -27,9 +29,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -46,9 +48,11 @@ public class ConfigurationController {
 
     @GetMapping(value = "/", produces = "application/json;")
     @ResponseBody
-    public ResponseEntity<List<PlatformDeployment>> displayConfigs() {
+    public ResponseEntity<Page<PlatformDeployment>> displayConfigs(
+            @RequestParam(defaultValue = "0") Integer page,
+            @RequestParam(defaultValue = "10") Integer size) {
 
-        List<PlatformDeployment> platformDeploymentListEntityList = platformDeploymentRepository.findAll();
+        Page<PlatformDeployment> platformDeploymentListEntityList = platformDeploymentRepository.findAll(PageRequest.of(page, size));
         if (platformDeploymentListEntityList.isEmpty()) {
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);
             // You many decide to return HttpStatus.NOT_FOUND

--- a/src/main/java/net/unicon/lti/model/PlatformDeployment.java
+++ b/src/main/java/net/unicon/lti/model/PlatformDeployment.java
@@ -12,6 +12,9 @@
  */
 package net.unicon.lti.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -53,6 +56,7 @@ public class PlatformDeployment extends BaseEntity {
     @Column(name = "deployment_id")
     private String deploymentId;  // Where in the platform we need to ask for the oidc authentication.
 
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @OneToMany(mappedBy = "platformDeployment", fetch = FetchType.LAZY)
     private Set<LtiContextEntity> contexts;
 
@@ -121,6 +125,7 @@ public class PlatformDeployment extends BaseEntity {
         this.deploymentId = deploymentId;
     }
 
+    @JsonIgnore
     public Set<LtiContextEntity> getContexts() {
         return contexts;
     }

--- a/src/test/java/net/unicon/lti/controller/lti/ConfigurationControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/ConfigurationControllerTest.java
@@ -10,15 +10,18 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
@@ -43,21 +46,24 @@ public class ConfigurationControllerTest {
 
     @Test
     public void testDisplayConfigs() {
-        ResponseEntity<List<PlatformDeployment>> platformDeploymentResponseEntity = new ResponseEntity<>(Arrays.asList(platformDeployment), HttpStatus.OK);
-        when(platformDeploymentRepository.findAll()).thenReturn(Arrays.asList(platformDeployment));
+        Page<PlatformDeployment> platformDeploymentPage = new PageImpl<>(Arrays.asList(platformDeployment));
+        ResponseEntity<Page<PlatformDeployment>> platformDeploymentResponseEntity = new ResponseEntity<>(platformDeploymentPage, HttpStatus.OK);
+        when(platformDeploymentRepository.findAll(any(PageRequest.class))).thenReturn(platformDeploymentPage);
 
-        ResponseEntity<List<PlatformDeployment>> found = configurationController.displayConfigs();
-        Mockito.verify(platformDeploymentRepository).findAll();
+        ResponseEntity<Page<PlatformDeployment>> found = configurationController.displayConfigs(0, 10);
+        Mockito.verify(platformDeploymentRepository).findAll(any(PageRequest.class));
         assertEquals(platformDeploymentResponseEntity.getStatusCode(), found.getStatusCode());
         assertEquals(platformDeploymentResponseEntity.getBody(), found.getBody());
     }
 
     @Test
     public void testDisplayConfigsNotFound() {
-        when(platformDeploymentRepository.findAll()).thenReturn(new ArrayList<>());
+        Page<PlatformDeployment> platformDeploymentPage = new PageImpl<>(new ArrayList<>());
+        ResponseEntity<Page<PlatformDeployment>> platformDeploymentResponseEntity = new ResponseEntity<>(platformDeploymentPage, HttpStatus.OK);
+        when(platformDeploymentRepository.findAll(any(PageRequest.class))).thenReturn(platformDeploymentPage);
 
-        ResponseEntity<List<PlatformDeployment>> found = configurationController.displayConfigs();
-        Mockito.verify(platformDeploymentRepository).findAll();
+        ResponseEntity<Page<PlatformDeployment>> found = configurationController.displayConfigs(0, 10);
+        Mockito.verify(platformDeploymentRepository).findAll(any(PageRequest.class));
         assertEquals(HttpStatus.NO_CONTENT, found.getStatusCode());
         assertNull(found.getBody());
     }


### PR DESCRIPTION
## Description
 - Removed the context field from the GET config output
 - Added pagination to GET config endpoint

### Motivation and Context
 - The bidirectional relationship between PlatformDeployment and LtiContext led to an infinite recursion in the JSON output from the GET config endpoint, making the output difficult to read, making it take longer, and preventing the entire set of PlatformDeployment configurations from being retrievable via this endpoint. Removing the context field from this JSON output has resolved those three issues.
 - Pagination was added to the GET config endpoint so that when the configuration database table grows to be large, its entirety is not fetched at once when the GET config endpoint is called, leading to slow requests.

### Fixes
[L3-74](https://lumenlearning.atlassian.net/browse/L3-74)

## How Has This Been Tested?
### Testing Removing the Context Field:
1. Postman was used to call a GET {{middleware_url}}/config/ 
2. Ensure that the output does not contain the context field
3. Postman was used to call a POST and PUT to {{middleware_url}}/config/  to ensure that nothing was inadvertently broken in these endpoints.
4. Postman was used to call a GET {{middleware_url}}/config/ to ensure that the new configuration generated in step 3 was retrievable.
5. I created a new course in Canvas and went through the LTI Core Standard Launch in this new course to add a new entry to the lti_contexts table.
6. Repeat steps 1-2.
7. I clicked on an LTI link associated with an assignment in various courses in Canvas and extracted the sub as the user_id and the lineitems url to generate an SQS message like `{"client_id": "97140000000000230", "user_id": "4f3d12df-e1ae-484f-8b9a-b667864e8100", "deployment_id": "461:5440a08422ab1ee7794a0588b5e4cb4a094c4256", "issuer": "https://canvas.instructure.com", "lineitem_url": "https://canvas.unicon.net/api/lti/courses/493/line_items/729", "score": 0.3}`.
8. I ensured that grades could still be posted and that the logging output could still retrieve lti_contexts from the db to identify what course a grade belonged to.

### Testing Pagination
1. Postman was used to call a GET {{middleware_url}}/config/ 
2. Verified that only 10 configurations were returned and that the json output included a "pageable" field with information about the total number of pages, total number of elements, and the size of this particular output.
3. Postman was used to call a GET {{middleware_url}}/config/ ?page=0
4. Verified that this produced the exact same output for steps 1-2.
5. Postman was used to call a GET {{middleware_url}}/config/ ?page=1
6. Verified that this resulted in returning 10 different configurations from the db with an updated "pageable" field.
7. Postman was used to call a GET {{middleware_url}}/config/ ?size=50
8. Verified that this resulted in returning all of the configurations from the db (my local only has 21). The "pageable" field now indicates that the page size is 50, 1 totalPages, and 21 totalElements.

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
