### PR TITLE
L3-68 fix issue of not allowing multiple deployments

### DIFF
--- a/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
@@ -71,17 +71,19 @@ public class LTI3Controller {
         //We will use this link to find the content to display.
         String link = req.getParameter("link");
 
-        try{
+        try {
             Jws<Claims> claims = ltijwtService.validateState(state);
             lti3Request = LTI3Request.getInstance(link); // validates nonce & id_token
             // This is just an extra check that we have added, but it is not necessary.
-            // Checking that the clientId in the status matches the one coming with the ltiRequest.
-            if (!claims.getBody().get("clientId").equals(lti3Request.getAud())) {
+            // Checking that the clientId in the state (if sent in OIDC initiation request) matches the one coming with the ltiRequest.
+            String clientIdFromState = claims.getBody().get("clientId") != null ? claims.getBody().get("clientId").toString() : null;
+            if (clientIdFromState != null && !clientIdFromState.equals(lti3Request.getAud())) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid client_id");
             }
             // This is just an extra check that we have added, but it is not necessary.
-            // Checking that the deploymentId in the status matches the one coming with the ltiRequest.
-            if (!claims.getBody().get("ltiDeploymentId").equals(lti3Request.getLtiDeploymentId())) {
+            // Checking that the deploymentId in the state (if sent in the OIDC initiation request) matches the one coming with the ltiRequest.
+            String deploymentIdFromState = claims.getBody().get("ltiDeploymentId") != null ? claims.getBody().get("ltiDeploymentId").toString() : null;
+            if (deploymentIdFromState != null && !deploymentIdFromState.equals(lti3Request.getLtiDeploymentId())) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid deployment_id");
             }
 

--- a/src/main/java/net/unicon/lti/controller/lti/OIDCController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/OIDCController.java
@@ -41,6 +41,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static net.unicon.lti.utils.LtiStrings.OIDC_CLIENT_ID;
+import static net.unicon.lti.utils.LtiStrings.OIDC_FORM_POST;
+import static net.unicon.lti.utils.LtiStrings.OIDC_ID_TOKEN;
+import static net.unicon.lti.utils.LtiStrings.OIDC_NONE;
+import static net.unicon.lti.utils.LtiStrings.OIDC_OPEN_ID;
+
 /**
  * This LTI controller should be protected by OAuth 1.0a (on the /oauth path)
  * This will handle LTI 1 and 2 (many of the paths ONLY make sense for LTI2 though)
@@ -51,14 +57,6 @@ import java.util.UUID;
 @Scope("session")
 @RequestMapping("/oidc")
 public class OIDCController {
-    //Constants defined in the LTI standard
-    private static final String NONE = "none";
-    private static final String FORM_POST = "form_post";
-    private static final String ID_TOKEN = "id_token";
-    private static final String OPEN_ID = "openid";
-    private static final String CLIENT_ID = "client_id";
-    private static final String DEPLOYMENT_ID = "lti_deployment_id";
-
     @Autowired
     PlatformDeploymentRepository platformDeploymentRepository;
 
@@ -74,57 +72,43 @@ public class OIDCController {
 
         // We need to receive the parameters and search for the deployment of the tool that matches with what we receive.
         LoginInitiationDTO loginInitiationDTO = new LoginInitiationDTO(req);
-        List<PlatformDeployment> platformDeploymentListEntityList;
+        List<PlatformDeployment> platformDeploymentList;
         // Getting the client_id (that is optional) and can come in the form or in the URL.
-        String clientIdValue;
-        // If we already have it in the loginInitiationDTO
-        if (loginInitiationDTO.getClientId() != null) {
-            clientIdValue = loginInitiationDTO.getClientId();
-        } else {  // We try to get it from the URL query parameters.
-            clientIdValue = req.getParameter(CLIENT_ID);
-        }
+        String clientIdValue = loginInitiationDTO.getClientId();
         // Getting the deployment_id (that is optional) and can come in the form or in the URL.
-        String deploymentIdValue;
-        // If we already have it in the loginInitiationDTO
-        if (loginInitiationDTO.getDeploymentId() != null) {
-            deploymentIdValue = loginInitiationDTO.getDeploymentId();
-        } else {  // We try to get it from the URL query getDeploymentId.
-            deploymentIdValue = req.getParameter(DEPLOYMENT_ID);
-        }
+        String deploymentIdValue = loginInitiationDTO.getDeploymentId();
 
         // We search for the platformDeployment.
         // We will try all the options here (from more detailed to less), and we will deal with the error if there are more than one result.
         if (clientIdValue != null && deploymentIdValue != null) {
-            platformDeploymentListEntityList = platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(loginInitiationDTO.getIss(), clientIdValue, deploymentIdValue);
+            platformDeploymentList = platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(loginInitiationDTO.getIss(), clientIdValue, deploymentIdValue);
         } else if (clientIdValue != null) {
-            platformDeploymentListEntityList = platformDeploymentRepository.findByIssAndClientId(loginInitiationDTO.getIss(), clientIdValue);
+            platformDeploymentList = platformDeploymentRepository.findByIssAndClientId(loginInitiationDTO.getIss(), clientIdValue);
         } else if (deploymentIdValue != null) {
-            platformDeploymentListEntityList = platformDeploymentRepository.findByIssAndDeploymentId(loginInitiationDTO.getIss(), deploymentIdValue);
+            platformDeploymentList = platformDeploymentRepository.findByIssAndDeploymentId(loginInitiationDTO.getIss(), deploymentIdValue);
         } else {
-            platformDeploymentListEntityList = platformDeploymentRepository.findByIss(loginInitiationDTO.getIss());
+            platformDeploymentList = platformDeploymentRepository.findByIss(loginInitiationDTO.getIss());
         }
         // We deal with some possible errors
-        if (platformDeploymentListEntityList.isEmpty()) {  //If we don't have configuration
+        if (platformDeploymentList.isEmpty()) {  //If we don't have configuration
             model.addAttribute(TextConstants.ERROR, "Not found any existing tool deployment with iss: " + loginInitiationDTO.getIss() +
                     " clientId: " + clientIdValue + " deploymentId: " + deploymentIdValue);
             return TextConstants.LTI3ERROR;
         }
-        if (platformDeploymentListEntityList.size() > 1) {   // If we have more than one match.
-            model.addAttribute(TextConstants.ERROR, "We have more than one tool deployment with iss: " + loginInitiationDTO.getIss() +
-                    " clientId: " + clientIdValue + " deploymentId: " + deploymentIdValue);
-            return TextConstants.LTI3ERROR;
+        PlatformDeployment platformDeployment = platformDeploymentList.get(0);
+        if (platformDeploymentList.size() == 1 && clientIdValue == null || deploymentIdValue == null) {
+            // If there is only one result, we know what the clientId and deploymentId will be
+            if (clientIdValue == null) {
+                clientIdValue = platformDeployment.getClientId();
+            }
+            if (deploymentIdValue == null) {
+                deploymentIdValue = platformDeployment.getDeploymentId();
+            }
         }
-        // If we have arrived here, it means that we have only one result (as expected)
-        PlatformDeployment lti3KeyEntity = platformDeploymentListEntityList.get(0);
-        if (clientIdValue == null) {
-            clientIdValue = lti3KeyEntity.getClientId();
-        }
-        if (deploymentIdValue == null) {
-            deploymentIdValue = lti3KeyEntity.getDeploymentId();
-        }
+
         try {
             // We are going to create the OIDC request,
-            Map<String, String> parameters = generateAuthRequestPayload(lti3KeyEntity, loginInitiationDTO, clientIdValue, deploymentIdValue);
+            Map<String, String> parameters = generateAuthRequestPayload(loginInitiationDTO, clientIdValue, deploymentIdValue, platformDeployment.getOidcEndpoint());
             // We add that information so the thymeleaf template can display it (and prepare the links)
             //model.addAllAttributes(parameters);
             // These 3 are to display what we received from the platform.
@@ -137,25 +121,13 @@ public class OIDCController {
             // This can be implemented in different ways, on this case, we are storing the state and nonce in
             // the httpsession, so we can compare later if they are valid states and nonces.
             HttpSession session = req.getSession();
-            List<String> stateList;
-            List<String> nonceList;
+            List<String> stateList = session.getAttribute("lti_state") != null ?
+                    (List) session.getAttribute("lti_state") :
+                    new ArrayList<>();
             String state = parameters.get("state");
-            String nonce = parameters.get("nonce");
 
             // We will keep several states and nonces, and we should delete them once we use them.
-            if (session.getAttribute("lti_state") != null) {
-                List<String> ltiState = (List) session.getAttribute("lti_state");
-                if (ltiState.isEmpty()) {  //If not old states... then just the one we have created
-                    stateList = new ArrayList<>();
-                    stateList.add(state);
-                } else if (ltiState.contains(state)) {  //if the state is already there... then the lti_state is the same. No need to add a duplicate
-                    stateList = ltiState;
-                } else { // if it is a different state and there are more... we add it with the to the string.
-                    ltiState.add(state);
-                    stateList = ltiState;
-                }
-            } else {
-                stateList = new ArrayList<>();
+            if (!stateList.contains(state)) { // if it is a different state and there are more... we add it with the to the string.
                 stateList.add(state);
             }
             session.setAttribute("lti_state", stateList);
@@ -163,17 +135,11 @@ public class OIDCController {
             log.debug("lti_state in session: {}", session.getAttribute("lti_state"));
             log.debug("Session ID in OIDC Controller: {}", session.getId());
 
-            if (session.getAttribute("lti_nonce") != null) {
-                List<String> ltiNonce = (List) session.getAttribute("lti_nonce");
-                if (ltiNonce.isEmpty()) {  //If not old nonces... then just the one we have created
-                    nonceList = new ArrayList<>();
-                    nonceList.add(nonce);
-                } else {
-                    ltiNonce.add(nonce);
-                    nonceList = ltiNonce;
-                }
-            } else {
-                nonceList = new ArrayList<>();
+            List<String> nonceList = session.getAttribute("lti_nonce") != null ?
+                    (List) session.getAttribute("lti_nonce") :
+                    new ArrayList<>();
+            String nonce = parameters.get("nonce");
+            if (!nonceList.contains(nonce)) {
                 nonceList.add(nonce);
             }
             session.setAttribute("lti_nonce", nonceList);
@@ -185,6 +151,7 @@ public class OIDCController {
                 return "oicdRedirect";
             }
         } catch (Exception ex) {
+            ex.printStackTrace();
             model.addAttribute(TextConstants.ERROR, ExceptionUtils.getStackTrace(ex));
             return TextConstants.LTI3ERROR;
         }
@@ -194,10 +161,11 @@ public class OIDCController {
      * This generates a map with all the information that we need to send to the OIDC Authorization endpoint in the Platform.
      * In this case, we will put this in the model to be used by the thymeleaf template.
      */
-    private Map<String, String> generateAuthRequestPayload(PlatformDeployment platformDeployment, LoginInitiationDTO loginInitiationDTO, String clientIdValue, String deploymentIdValue) throws GeneralSecurityException, IOException {
-
+    private Map<String, String> generateAuthRequestPayload(LoginInitiationDTO loginInitiationDTO, String clientIdValue, String deploymentIdValue, String oidcEndpoint) throws GeneralSecurityException, IOException {
         Map<String, String> authRequestMap = new HashMap<>();
-        authRequestMap.put(CLIENT_ID, platformDeployment.getClientId()); //As it came from the Platform (if it came... if not we should have it configured)
+        if (clientIdValue != null) {
+            authRequestMap.put(OIDC_CLIENT_ID, clientIdValue); //As it came from the Platform (if it came or was found in config)
+        }
         authRequestMap.put("login_hint", loginInitiationDTO.getLoginHint()); //As it came from the Platform
         authRequestMap.put("lti_message_hint", loginInitiationDTO.getLtiMessageHint()); //As it came from the Platform
         String nonce = UUID.randomUUID().toString(); // We generate a nonce to allow this auth request to be used only one time.
@@ -206,16 +174,16 @@ public class OIDCController {
                 .toString();
         authRequestMap.put("nonce", nonce);  //The nonce
         authRequestMap.put("nonce_hash", nonceHash);  //The hash value of the nonce
-        authRequestMap.put("prompt", NONE);  //Always this value, as specified in the standard.
+        authRequestMap.put("prompt", OIDC_NONE);  //Always this value, as specified in the standard.
         authRequestMap.put("redirect_uri", ltiDataService.getLocalUrl() + TextConstants.LTI3_SUFFIX);  // One of the valid redirect uris.
-        authRequestMap.put("response_mode", FORM_POST); //Always this value, as specified in the standard.
-        authRequestMap.put("response_type", ID_TOKEN); //Always this value, as specified in the standard.
-        authRequestMap.put("scope", OPEN_ID);  //Always this value, as specified in the standard.
+        authRequestMap.put("response_mode", OIDC_FORM_POST); //Always this value, as specified in the standard.
+        authRequestMap.put("response_type", OIDC_ID_TOKEN); //Always this value, as specified in the standard.
+        authRequestMap.put("scope", OIDC_OPEN_ID);  //Always this value, as specified in the standard.
         // The state is something that we can create and add anything we want on it.
         // On this case, we have decided to create a JWT token with some information that we will use as additional security. But it is not mandatory.
-        String state = LtiOidcUtils.generateState(ltiDataService, platformDeployment, authRequestMap, loginInitiationDTO, clientIdValue, deploymentIdValue);
+        String state = LtiOidcUtils.generateState(ltiDataService, authRequestMap, loginInitiationDTO, clientIdValue, deploymentIdValue);
         authRequestMap.put("state", state); //The state we use later to retrieve some useful information about the OICD request.
-        authRequestMap.put("oicdEndpoint", platformDeployment.getOidcEndpoint());  //We need this in the Thymeleaf template in case we decide to use the POST method. It is the endpoint where the LMS receives the OICD requests
+        authRequestMap.put("oicdEndpoint", oidcEndpoint);  //We need this in the Thymeleaf template in case we decide to use the POST method. It is the endpoint where the LMS receives the OICD requests
         authRequestMap.put("oicdEndpointComplete", generateCompleteUrl(authRequestMap));  //This generates the URL to use in case we decide to use the GET method
         return authRequestMap;
     }
@@ -227,7 +195,12 @@ public class OIDCController {
         StringBuilder getUrl = new StringBuilder();
 
         getUrl.append(model.get("oicdEndpoint"));
-        getUrl = addParameter(getUrl, "client_id", model.get(CLIENT_ID), true);
+        if (model.get(OIDC_CLIENT_ID) != null) {
+            getUrl = addParameter(getUrl, "client_id", model.get(OIDC_CLIENT_ID), true);
+            getUrl = addParameter(getUrl, "login_hint", model.get("login_hint"), false);
+        } else {
+            getUrl = addParameter(getUrl, "login_hint", model.get("login_hint"), true);
+        }
         getUrl = addParameter(getUrl, "login_hint", model.get("login_hint"), false);
         getUrl = addParameter(getUrl, "lti_message_hint", model.get("lti_message_hint"), false);
         getUrl = addParameter(getUrl, "nonce", model.get("nonce_hash"), false);

--- a/src/main/java/net/unicon/lti/model/lti/dto/LoginInitiationDTO.java
+++ b/src/main/java/net/unicon/lti/model/lti/dto/LoginInitiationDTO.java
@@ -14,6 +14,13 @@ package net.unicon.lti.model.lti.dto;
 
 import javax.servlet.http.HttpServletRequest;
 
+import static net.unicon.lti.utils.LtiStrings.OIDC_CLIENT_ID;
+import static net.unicon.lti.utils.LtiStrings.OIDC_DEPLOYMENT_ID;
+import static net.unicon.lti.utils.LtiStrings.OIDC_ISS;
+import static net.unicon.lti.utils.LtiStrings.OIDC_LOGIN_HINT;
+import static net.unicon.lti.utils.LtiStrings.OIDC_LTI_MESSAGE_HINT;
+import static net.unicon.lti.utils.LtiStrings.OIDC_TARGET_LINK_URI;
+
 public class LoginInitiationDTO {
 
     private String iss;
@@ -37,12 +44,12 @@ public class LoginInitiationDTO {
     }
 
     public LoginInitiationDTO(HttpServletRequest req) {
-        this(req.getParameter("iss"),
-                req.getParameter("login_hint"),
-                req.getParameter("target_link_uri"),
-                req.getParameter("lti_message_hint"),
-                req.getParameter("client_id"),
-                req.getParameter("lti_deployment_id")
+        this(req.getParameter(OIDC_ISS),
+                req.getParameter(OIDC_LOGIN_HINT),
+                req.getParameter(OIDC_TARGET_LINK_URI),
+                req.getParameter(OIDC_LTI_MESSAGE_HINT),
+                req.getParameter(OIDC_CLIENT_ID),
+                req.getParameter(OIDC_DEPLOYMENT_ID)
         );
     }
 

--- a/src/main/java/net/unicon/lti/security/lti/LTI3OAuthProviderProcessingFilter.java
+++ b/src/main/java/net/unicon/lti/security/lti/LTI3OAuthProviderProcessingFilter.java
@@ -131,7 +131,7 @@ public class LTI3OAuthProviderProcessingFilter extends GenericFilterBean {
                 if (jws != null) {
                     //Here we create and populate the LTI3Request object and we will add it to the httpServletRequest, so the redirect endpoint will have all that information
                     //ready and will be able to use it.
-                    LTI3Request lti3Request = new LTI3Request(httpServletRequest, ltiDataService, true, link); // IllegalStateException if invalid
+                    LTI3Request lti3Request = new LTI3Request(httpServletRequest, ltiDataService, true, link, null); // IllegalStateException if invalid
                     httpServletRequest.setAttribute("LTI3", true); // indicate this request is an LTI3 one
                     httpServletRequest.setAttribute("lti3_valid", lti3Request.isLoaded() && lti3Request.isComplete()); // is LTI3 request totally valid and complete
                     httpServletRequest.setAttribute("lti3_message_type", lti3Request.getLtiMessageType()); // is LTI3 request totally valid and complete

--- a/src/main/java/net/unicon/lti/utils/LtiStrings.java
+++ b/src/main/java/net/unicon/lti/utils/LtiStrings.java
@@ -24,6 +24,18 @@ public class LtiStrings {
     public static final int ROLE_STUDENT = 0;
     public static final int ROLE_INSTRUCTOR = 1;
 
+    // OIDC Initiation Parameters
+    public static final String OIDC_NONE = "none";
+    public static final String OIDC_FORM_POST = "form_post";
+    public static final String OIDC_ID_TOKEN = "id_token";
+    public static final String OIDC_OPEN_ID = "openid";
+    public static final String OIDC_ISS = "iss";
+    public static final String OIDC_LOGIN_HINT = "login_hint";
+    public static final String OIDC_LTI_MESSAGE_HINT = "lti_message_hint";
+    public static final String OIDC_TARGET_LINK_URI = "target_link_uri";
+    public static final String OIDC_CLIENT_ID = "client_id";
+    public static final String OIDC_DEPLOYMENT_ID = "lti_deployment_id";
+
     //Those are used by the session.
     public static final String LTI_SESSION_USER_ID = "user_id";
     public static final String LTI_SESSION_USER_ROLE = "user_role";

--- a/src/main/java/net/unicon/lti/utils/lti/LtiOidcUtils.java
+++ b/src/main/java/net/unicon/lti/utils/lti/LtiOidcUtils.java
@@ -15,7 +15,6 @@ package net.unicon.lti.utils.lti;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.extern.slf4j.Slf4j;
-import net.unicon.lti.model.PlatformDeployment;
 import net.unicon.lti.model.lti.dto.LoginInitiationDTO;
 import net.unicon.lti.service.lti.LTIDataService;
 import net.unicon.lti.utils.TextConstants;
@@ -40,15 +39,15 @@ public final class LtiOidcUtils {
      * The state will be returned when the tool makes the final call to us, so it is useful to send information
      * to our own tool, to know about the request.
      */
-    public static String generateState(LTIDataService ltiDataService, PlatformDeployment platformDeployment, Map<String, String> authRequestMap, LoginInitiationDTO loginInitiationDTO, String clientIdValue, String deploymentIdValue) throws GeneralSecurityException {
+    public static String generateState(LTIDataService ltiDataService, Map<String, String> authRequestMap, LoginInitiationDTO loginInitiationDTO, String clientIdValue, String deploymentIdValue) throws GeneralSecurityException {
         LocalDateTime date = LocalDateTime.now(ZoneId.of("Z"));
         Key issPrivateKey = OAuthUtils.loadPrivateKey(ltiDataService.getOwnPrivateKey());
         String state = Jwts.builder()
                 .setHeaderParam("kid", TextConstants.DEFAULT_KID)  // The key id used to sign this
                 .setHeaderParam("typ", "JWT") // The type
                 .setIssuer("ltiMiddleware")  //This is our own identifier, to know that we are the issuer.
-                .setSubject(platformDeployment.getIss()) // We store here the platform issuer to check that matches with the issuer received later
-                .setAudience(platformDeployment.getClientId())  //We send here the clientId to check it later.
+                .setSubject(loginInitiationDTO.getIss()) // We store here the platform issuer to check that matches with the issuer received later
+                .setAudience(clientIdValue)  //We send here the clientId to check it later.
                 .setExpiration(Date.from(date.plusHours(1).toInstant(ZoneOffset.UTC))) //a java.util.Date
                 .setNotBefore(Date.from(date.toInstant(ZoneOffset.UTC))) //a java.util.Date
                 .setIssuedAt(Date.from(date.toInstant(ZoneOffset.UTC))) // for example, now

--- a/src/test/java/net/unicon/lti/controller/lti/OIDCControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/OIDCControllerTest.java
@@ -1,0 +1,273 @@
+package net.unicon.lti.controller.lti;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import net.unicon.lti.model.PlatformDeployment;
+import net.unicon.lti.repository.PlatformDeploymentRepository;
+import net.unicon.lti.service.lti.LTIDataService;
+import net.unicon.lti.utils.TextConstants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+
+import static net.unicon.lti.utils.LtiStrings.OIDC_CLIENT_ID;
+import static net.unicon.lti.utils.LtiStrings.OIDC_DEPLOYMENT_ID;
+import static net.unicon.lti.utils.LtiStrings.OIDC_FORM_POST;
+import static net.unicon.lti.utils.LtiStrings.OIDC_ID_TOKEN;
+import static net.unicon.lti.utils.LtiStrings.OIDC_ISS;
+import static net.unicon.lti.utils.LtiStrings.OIDC_LOGIN_HINT;
+import static net.unicon.lti.utils.LtiStrings.OIDC_LTI_MESSAGE_HINT;
+import static net.unicon.lti.utils.LtiStrings.OIDC_NONE;
+import static net.unicon.lti.utils.LtiStrings.OIDC_OPEN_ID;
+import static net.unicon.lti.utils.LtiStrings.OIDC_TARGET_LINK_URI;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+@WebMvcTest(LTI3Controller.class)
+public class OIDCControllerTest {
+    private static final String SAMPLE_LOGIN_HINT = "sample-login-hint-from-platform";
+    private static final String SAMPLE_TARGET_URI = "https://lti-tool.com/lti3";
+    private static final String SAMPLE_LTI_MESSAGE_HINT = "sample-message-hint-from-platform";
+    private static final String SAMPLE_ISS = "https://platform-lms.com";
+    private static final String SAMPLE_CLIENT_ID = "sample-client-id";
+    private static final String SAMPLE_DEPLOYMENT_ID = "sample-deployment-id";
+    private static final String SAMPLE_OIDC_ENDPOINT = "https://platform-lms.com/oidc";
+    private static final String SAMPLE_ENCODED_REDIRECT_URI = "https%3A%2F%2Flti-tool.com%2Flti3%2F";
+
+
+    @InjectMocks
+    private OIDCController oidcController = new OIDCController();
+
+    @MockBean
+    private PlatformDeploymentRepository platformDeploymentRepository;
+
+    @MockBean
+    private LTIDataService ltiDataService;
+
+    @Mock
+    private HttpServletRequest req;
+
+    @Mock
+    private HttpServletResponse res;
+
+    @Mock
+    private PlatformDeployment platformDeployment1;
+
+    @Mock
+    private PlatformDeployment platformDeployment2;
+
+    private MockHttpSession mockHttpSession = new MockHttpSession();
+
+    private List<PlatformDeployment> onePlatformDeployment;
+    private List<PlatformDeployment> multiplePlatformDeployments;
+
+    private KeyPair kp;
+
+    private Model model = new ExtendedModelMap();
+
+    @Configuration
+    static class ContextConfiguration {
+
+    }
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        onePlatformDeployment = Arrays.asList(platformDeployment1);
+        multiplePlatformDeployments = Arrays.asList(platformDeployment1, platformDeployment2);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class)))
+                .thenReturn(onePlatformDeployment);
+        when(platformDeploymentRepository.findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID)))
+                .thenReturn(multiplePlatformDeployments);
+        when(platformDeploymentRepository.findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID)))
+                .thenReturn(onePlatformDeployment);
+        when(platformDeploymentRepository.findByIss(eq(SAMPLE_ISS)))
+                .thenReturn(multiplePlatformDeployments);
+        when(ltiDataService.getDemoMode()).thenReturn(false);
+        when(req.getSession()).thenReturn(mockHttpSession);
+        when(ltiDataService.getLocalUrl()).thenReturn("https://lti-tool.com");
+        when(platformDeployment1.getOidcEndpoint()).thenReturn(SAMPLE_OIDC_ENDPOINT);
+        when(platformDeployment2.getOidcEndpoint()).thenReturn(SAMPLE_OIDC_ENDPOINT);
+
+        try {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+            kpg.initialize(1024);
+            kp = kpg.generateKeyPair();
+            Base64.Encoder encoder = Base64.getEncoder();
+            String privateKey = "-----BEGIN PRIVATE KEY-----\n" + encoder.encodeToString(kp.getPrivate().getEncoded()) + "\n-----END PRIVATE KEY-----\n";
+            when(ltiDataService.getOwnPrivateKey()).thenReturn(privateKey);
+        } catch(NoSuchAlgorithmException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerAndClientIdAndDeploymentId() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(SAMPLE_CLIENT_ID);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(SAMPLE_DEPLOYMENT_ID);
+
+        String response = oidcController.loginInitiations(req, res, model);
+
+        Mockito.verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID);
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerAndClientId() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(SAMPLE_CLIENT_ID);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(null);
+
+        String response = oidcController.loginInitiations(req, res, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID);
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuer() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(null);
+
+        String response = oidcController.loginInitiations(req, res, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, null);
+
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerAndDeploymentId() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(SAMPLE_DEPLOYMENT_ID);
+
+        String response = oidcController.loginInitiations(req, res, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, null);
+
+    }
+
+    @Test
+    public void testLoginInitiationWithoutConfigIdentifiers() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(null);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(null);
+
+        String response = oidcController.loginInitiations(req, res, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(null), eq(null), eq(null));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(null), eq(null));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(null), eq(null));
+        Mockito.verify(platformDeploymentRepository).findByIss(eq(null));
+        Mockito.verify(req, never()).getSession();
+        Mockito.verify(ltiDataService, never()).getLocalUrl();
+        Mockito.verify(ltiDataService, never()).getOwnPrivateKey();
+
+        assertEquals(TextConstants.LTI3ERROR, response);
+    }
+
+    @Test
+    public void testLoginInitiationWithoutIss() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(null);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(SAMPLE_CLIENT_ID);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(SAMPLE_DEPLOYMENT_ID);
+
+        String response = oidcController.loginInitiations(req, res, model);
+
+        Mockito.verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(eq(null), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(null), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(null), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(null));
+        Mockito.verify(req, never()).getSession();
+        Mockito.verify(ltiDataService, never()).getLocalUrl();
+        Mockito.verify(ltiDataService, never()).getOwnPrivateKey();
+
+        assertEquals(TextConstants.LTI3ERROR, response);
+    }
+
+    private void validateOAuthResponse(String response, String clientId) {
+        UriComponents responseUri = UriComponentsBuilder.fromUriString(response.substring("redirect:".length())).build();
+        assertEquals(SAMPLE_OIDC_ENDPOINT, responseUri.getScheme() + "://" + responseUri.getHost() + responseUri.getPath());
+        MultiValueMap<String, String> parameters = responseUri.getQueryParams();
+
+        if (clientId != null) {
+            assertEquals(clientId, parameters.get("client_id").get(0));
+        } else {
+            assertNull(parameters.get("client_id"));
+        }
+        assertEquals(SAMPLE_LOGIN_HINT, parameters.get("login_hint").get(0));
+        assertEquals(SAMPLE_LTI_MESSAGE_HINT, parameters.get("lti_message_hint").get(0));
+        assertEquals(OIDC_NONE, parameters.get("prompt").get(0));
+        assertEquals(SAMPLE_ENCODED_REDIRECT_URI, parameters.get("redirect_uri").get(0));
+        assertEquals(OIDC_FORM_POST, parameters.get("response_mode").get(0));
+        assertEquals(OIDC_ID_TOKEN, parameters.get("response_type").get(0));
+        assertEquals(OIDC_OPEN_ID, parameters.get("scope").get(0));
+        assertTrue(parameters.get("nonce").get(0).length() >= 36);
+        Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(parameters.get("state").get(0));
+        assertNotNull(finalClaims);
+    }
+}

--- a/src/test/java/net/unicon/lti/utils/lti/LTI3RequestTest.java
+++ b/src/test/java/net/unicon/lti/utils/lti/LTI3RequestTest.java
@@ -1,0 +1,208 @@
+package net.unicon.lti.utils.lti;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import net.unicon.lti.model.PlatformDeployment;
+import net.unicon.lti.repository.AllRepositories;
+import net.unicon.lti.repository.PlatformDeploymentRepository;
+import net.unicon.lti.service.lti.LTIDataService;
+import net.unicon.lti.utils.LtiStrings;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mock.web.MockHttpSession;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LTI3RequestTest {
+    private static String ID_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjIwMjEtMDktMDFUMDA6MTQ6MzdaIn0.eyJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS9jbGFpbS9tZXNzYWdlX3R5cGUiOiJMdGlSZXNvdXJjZUxpbmtSZXF1ZXN0IiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vdmVyc2lvbiI6IjEuMy4wIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vcmVzb3VyY2VfbGluayI6eyJpZCI6IjcxZTViNWNiLTZmMDUtNGQ1My1iN2U5LWQxMmVjZDQ3NWU3NiIsImRlc2NyaXB0aW9uIjoiIiwidGl0bGUiOiJTdHVkeSBQbGFuOiBUaGUgRXRpb2xvZ3kgYW5kIFRyZWF0bWVudCBvZiBNZW50YWwgRGlzb3JkZXJzIiwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJhdWQiOiI5NzE0MDAwMDAwMDAwMDIzMCIsImF6cCI6Ijk3MTQwMDAwMDAwMDAwMjMwIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vZGVwbG95bWVudF9pZCI6IjQ2MTo1NDQwYTA4NDIyYWIxZWU3Nzk0YTA1ODhiNWU0Y2I0YTA5NGM0MjU2IiwiZXhwIjoxNjMzNTQyMzczLCJpYXQiOjE2MzM1Mzg3NzMsImlzcyI6Imh0dHBzOi8vY2FudmFzLmluc3RydWN0dXJlLmNvbSIsIm5vbmNlIjoiNWQwNGNiMTJmNDVkZjZlZTM3M2M0MmExY2E0Y2RiZTA4ZTJiZmE4ZTVmN2M2NjJhY2EzZjY1NjA2ODdmZGM0NyIsInN1YiI6IjRmM2QxMmRmLWUxYWUtNDg0Zi04YjlhLWI2Njc4NjRlODEwMCIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL3RhcmdldF9saW5rX3VyaSI6Imh0dHBzOi8vZ29sZGlsb2Nrcy5sdW1lbmxlYXJuaW5nLmNvbS9zdHVkeV9wbGFuLzdjM2EzOTE1LWZmZGEtNGU4Ny05MTQ5LTE2YzFhYzUyM2IyZj9laWQ9YUd3d0x3QndrdFpnelp0cENKWGVaZyIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2NvbnRleHQiOnsiaWQiOiIwYTQ3ZGU5MWNmODRlZTE0N2Y2ZTUzNDE5NTk4ODUwODUwNGQzZTgyIiwibGFiZWwiOiJtZ3dvemR6LWx1bWVuIiwidGl0bGUiOiJtZ3dvemR6IEx1bWVuIFRlc3QiLCJ0eXBlIjpbImh0dHA6Ly9wdXJsLmltc2dsb2JhbC5vcmcvdm9jYWIvbGlzL3YyL2NvdXJzZSNDb3Vyc2VPZmZlcmluZyJdLCJ2YWxpZGF0aW9uX2NvbnRleHQiOm51bGwsImVycm9ycyI6eyJlcnJvcnMiOnt9fX0sImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL3Rvb2xfcGxhdGZvcm0iOnsiZ3VpZCI6InBvdDI4eU5wRFNaczFGdk1RYTQyTWlQV2xST0xRQ0FlZHpRWDZNYzI6Y2FudmFzLWxtcyIsIm5hbWUiOiJVbmljb24iLCJ2ZXJzaW9uIjoiY2xvdWQiLCJwcm9kdWN0X2ZhbWlseV9jb2RlIjoiY2FudmFzIiwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS9jbGFpbS9sYXVuY2hfcHJlc2VudGF0aW9uIjp7ImRvY3VtZW50X3RhcmdldCI6ImlmcmFtZSIsImhlaWdodCI6bnVsbCwid2lkdGgiOm51bGwsInJldHVybl91cmwiOiJodHRwczovL3VuaWNvbi5pbnN0cnVjdHVyZS5jb20vY291cnNlcy8zMzQ4L2V4dGVybmFsX2NvbnRlbnQvc3VjY2Vzcy9leHRlcm5hbF90b29sX3JlZGlyZWN0IiwibG9jYWxlIjoiZW4iLCJ2YWxpZGF0aW9uX2NvbnRleHQiOm51bGwsImVycm9ycyI6eyJlcnJvcnMiOnt9fX0sImxvY2FsZSI6ImVuIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vcm9sZXMiOlsiaHR0cDovL3B1cmwuaW1zZ2xvYmFsLm9yZy92b2NhYi9saXMvdjIvaW5zdGl0dXRpb24vcGVyc29uI0FkbWluaXN0cmF0b3IiLCJodHRwOi8vcHVybC5pbXNnbG9iYWwub3JnL3ZvY2FiL2xpcy92Mi9pbnN0aXR1dGlvbi9wZXJzb24jSW5zdHJ1Y3RvciIsImh0dHA6Ly9wdXJsLmltc2dsb2JhbC5vcmcvdm9jYWIvbGlzL3YyL2luc3RpdHV0aW9uL3BlcnNvbiNTdHVkZW50IiwiaHR0cDovL3B1cmwuaW1zZ2xvYmFsLm9yZy92b2NhYi9saXMvdjIvbWVtYmVyc2hpcCNJbnN0cnVjdG9yIiwiaHR0cDovL3B1cmwuaW1zZ2xvYmFsLm9yZy92b2NhYi9saXMvdjIvc3lzdGVtL3BlcnNvbiNVc2VyIl0sImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2N1c3RvbSI6eyJkdWVfYXQiOiIkQ2FudmFzLmFzc2lnbm1lbnQuZHVlQXQuaXNvODYwMSIsImxvY2tfYXQiOiIkQ2FudmFzLmFzc2lnbm1lbnQubG9ja0F0Lmlzbzg2MDEiLCJ1bmxvY2tfYXQiOiIkQ2FudmFzLmFzc2lnbm1lbnQudW5sb2NrQXQuaXNvODYwMSIsImNhbnZhc191c2VyX2lkIjozODYsImNhbnZhc19sb2dpbl9pZCI6Im1nd296ZHpAdW5pY29uLm5ldCIsImNhbnZhc19jb3Vyc2VfaWQiOjMzNDgsImNhbnZhc191c2VyX25hbWUiOiJtZ3dvemR6QHVuaWNvbi5uZXQiLCJjYW52YXNfYXNzaWdubWVudF9pZCI6NjI3MX0sImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2x0aTExX2xlZ2FjeV91c2VyX2lkIjoiNDA3YTQxODI1MDdmMGYzN2E1NGVjNTVkNTAxOTM5YzFkM2QxMDJlNiIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpL2NsYWltL2x0aTFwMSI6eyJ1c2VyX2lkIjoiNDA3YTQxODI1MDdmMGYzN2E1NGVjNTVkNTAxOTM5YzFkM2QxMDJlNiIsInZhbGlkYXRpb25fY29udGV4dCI6bnVsbCwiZXJyb3JzIjp7ImVycm9ycyI6e319fSwiZXJyb3JzIjp7ImVycm9ycyI6e319LCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS1hZ3MvY2xhaW0vZW5kcG9pbnQiOnsic2NvcGUiOlsiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGktYWdzL3Njb3BlL2xpbmVpdGVtIiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGktYWdzL3Njb3BlL2xpbmVpdGVtLnJlYWRvbmx5IiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGktYWdzL3Njb3BlL3Jlc3VsdC5yZWFkb25seSIsImh0dHBzOi8vcHVybC5pbXNnbG9iYWwub3JnL3NwZWMvbHRpLWFncy9zY29wZS9zY29yZSJdLCJsaW5laXRlbXMiOiJodHRwczovL3VuaWNvbi5pbnN0cnVjdHVyZS5jb20vYXBpL2x0aS9jb3Vyc2VzLzMzNDgvbGluZV9pdGVtcyIsImxpbmVpdGVtIjoiaHR0cHM6Ly91bmljb24uaW5zdHJ1Y3R1cmUuY29tL2FwaS9sdGkvY291cnNlcy8zMzQ4L2xpbmVfaXRlbXMvNTAzIiwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJwaWN0dXJlIjoiaHR0cHM6Ly9jYW52YXMuaW5zdHJ1Y3R1cmUuY29tL2ltYWdlcy9tZXNzYWdlcy9hdmF0YXItNTAucG5nIiwiZW1haWwiOiJtZ3dvemR6QHVuaWNvbi5uZXQiLCJuYW1lIjoiTWFyeSBHd296ZHoiLCJnaXZlbl9uYW1lIjoiTWFyeSIsImZhbWlseV9uYW1lIjoiR3dvemR6IiwiaHR0cHM6Ly9wdXJsLmltc2dsb2JhbC5vcmcvc3BlYy9sdGkvY2xhaW0vbGlzIjp7InBlcnNvbl9zb3VyY2VkaWQiOiJtZ3dvemR6IiwiY291cnNlX29mZmVyaW5nX3NvdXJjZWRpZCI6bnVsbCwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJodHRwczovL3B1cmwuaW1zZ2xvYmFsLm9yZy9zcGVjL2x0aS1ucnBzL2NsYWltL25hbWVzcm9sZXNlcnZpY2UiOnsiY29udGV4dF9tZW1iZXJzaGlwc191cmwiOiJodHRwczovL3VuaWNvbi5pbnN0cnVjdHVyZS5jb20vYXBpL2x0aS9jb3Vyc2VzLzMzNDgvbmFtZXNfYW5kX3JvbGVzIiwic2VydmljZV92ZXJzaW9ucyI6WyIyLjAiXSwidmFsaWRhdGlvbl9jb250ZXh0IjpudWxsLCJlcnJvcnMiOnsiZXJyb3JzIjp7fX19LCJodHRwczovL3d3dy5pbnN0cnVjdHVyZS5jb20vcGxhY2VtZW50IjpudWxsfQ.qN6MqcitF8VHuMVk_YmuXnKN43A1TgdjbSV8zHxT6SS5uZo8vtTB2GBGmqPpsknTmJPNijpQsPMoeLN3kKAvkpJ0RJPWMYud89a1SGnons8HuqXxACUCwUa7Lki8j7xSIXB6tgXQqzkrHCPmsBwLQy6rAYseiDNpsLkzIZzBAZjt89262i_UxRScJkhdPF4GEQDw4d2d1YMM5cmSy039BZZyT7AOV4q3qjo_BeFlQ5QJjXDtXGZ5VIcOuyLipAcrG8a2llXd8gLDkxkD0gIwI_zZX2fG-XKHc_co_gp45L2fVz09vKS5R-yCiooZgktOBoe0OEY8vHfCbBk4Vj2sxg";
+    private static final String SAMPLE_ISS = "https://platform-lms.com";
+    private static final String SAMPLE_CLIENT_ID = "sample-client-id";
+    private static final String SAMPLE_DEPLOYMENT_ID = "sample-deployment-id";
+
+    @Mock
+    private LTIDataService ltiDataService;
+
+    @InjectMocks
+    private AllRepositories allRepositories;
+
+    @Mock
+    private PlatformDeploymentRepository platformDeploymentRepository;
+
+    @Mock
+    private HttpServletRequest req;
+
+    @Mock
+    private PlatformDeployment platformDeployment;
+
+    @Mock
+    Jws<Claims> jwsClaims;
+
+    @Mock
+    Claims claims;
+
+    private List<PlatformDeployment> platformDeploymentList;
+
+    private MockHttpSession mockHttpSession = new MockHttpSession();
+
+    @Configuration
+    static class ContextConfiguration {
+
+    }
+
+    @BeforeEach()
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        platformDeploymentList = Arrays.asList(platformDeployment);
+        when(ltiDataService.getRepos()).thenReturn(allRepositories);
+        when(jwsClaims.getBody()).thenReturn(claims);
+        when(req.getSession()).thenReturn(mockHttpSession);
+    }
+
+    @Test
+    public void testLTI3RequestWithoutRequest() {
+        AssertionError exception = Assertions.assertThrows(
+                AssertionError.class,
+                () -> {new LTI3Request(null, ltiDataService, false, "1234", jwsClaims);}
+        );
+        assertEquals(exception.getMessage(), "cannot make an LtiRequest without a request");
+    }
+
+    @Test
+    public void testLTI3RequestWithoutDataService() {
+        AssertionError exception = Assertions.assertThrows(
+                AssertionError.class,
+                () -> {new LTI3Request(req, null, false, "1234", jwsClaims);}
+        );
+        assertEquals(exception.getMessage(), "LTIDataService cannot be null");
+    }
+
+    @Test
+    public void testLTI3RequestWithoutDeployment() {
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class))).thenReturn(new ArrayList<>());
+        when(claims.getIssuer()).thenReturn(SAMPLE_ISS);
+        when(claims.getAudience()).thenReturn(SAMPLE_CLIENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_DEPLOYMENT_ID))).thenReturn(SAMPLE_DEPLOYMENT_ID);
+
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {new LTI3Request(req, ltiDataService, false, "1234", jwsClaims);}
+        );
+        verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class));
+        assertEquals("PlatformDeployment does not exist or is duplicated for issuer: https://platform-lms.com, clientId: sample-client-id, and deploymentId: sample-deployment-id", exception.getMessage());
+    }
+
+    @Test
+    public void testLTI3RequestWithDuplicateDeployment() {
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class))).thenReturn(Arrays.asList(platformDeployment, platformDeployment));
+        when(claims.getIssuer()).thenReturn(SAMPLE_ISS);
+        when(claims.getAudience()).thenReturn(SAMPLE_CLIENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_DEPLOYMENT_ID))).thenReturn(SAMPLE_DEPLOYMENT_ID);
+
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {new LTI3Request(req, ltiDataService, false, "1234", jwsClaims);}
+        );
+        verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class));
+        assertEquals("PlatformDeployment does not exist or is duplicated for issuer: https://platform-lms.com, clientId: sample-client-id, and deploymentId: sample-deployment-id", exception.getMessage());
+    }
+
+    @Test
+    public void testLTI3RequestWithInvalidMessageType() {
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class))).thenReturn(platformDeploymentList);
+        when(claims.getIssuer()).thenReturn(SAMPLE_ISS);
+        when(claims.getAudience()).thenReturn(SAMPLE_CLIENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_DEPLOYMENT_ID))).thenReturn(SAMPLE_DEPLOYMENT_ID);
+
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {new LTI3Request(req, ltiDataService, false, "1234", jwsClaims);}
+        );
+        verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_VERSION), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class));
+        assertEquals("Request is not a valid LTI3 request: LTI Version = null. LTI Message Type = null. ", exception.getMessage());
+    }
+
+    @Test
+    public void testLTI3RequestWithMissingNonce() {
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class))).thenReturn(platformDeploymentList);
+        when(claims.getIssuer()).thenReturn(SAMPLE_ISS);
+        when(claims.getAudience()).thenReturn(SAMPLE_CLIENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_DEPLOYMENT_ID))).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_VERSION), eq(String.class))).thenReturn(LtiStrings.LTI_VERSION_3);
+        when(claims.get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class))).thenReturn(LtiStrings.LTI_MESSAGE_TYPE_RESOURCE_LINK);
+        mockHttpSession.setAttribute("lti_nonce", new ArrayList<String>());
+        when(claims.get(eq(LtiStrings.LTI_NONCE), eq(String.class))).thenReturn("5d04cb12f45df6ee373c42a1ca4cdbe08e2bfa8e5f7c662aca3f6560687fdc47");
+
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {new LTI3Request(req, ltiDataService, false, "1234", jwsClaims);}
+        );
+        verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_VERSION), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_NONCE), eq(String.class));
+        assertEquals("Nonce error: Nonce = null in the JWT or in the session.", exception.getMessage());
+    }
+
+    @Test
+    public void testLTI3RequestWithInvalidNonce() {
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class))).thenReturn(platformDeploymentList);
+        when(claims.getIssuer()).thenReturn(SAMPLE_ISS);
+        when(claims.getAudience()).thenReturn(SAMPLE_CLIENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_DEPLOYMENT_ID))).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_VERSION), eq(String.class))).thenReturn(LtiStrings.LTI_VERSION_3);
+        when(claims.get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class))).thenReturn(LtiStrings.LTI_MESSAGE_TYPE_RESOURCE_LINK);
+        mockHttpSession.setAttribute("lti_nonce", Arrays.asList("5d04cb12f45df6ee373c42a1ca4cdbe08e2bfa8e5f7c662aca3f6560687fdc47"));
+        when(claims.get(eq(LtiStrings.LTI_NONCE), eq(String.class))).thenReturn("5d04cb12f45df6ee373c42a1ca4cdbe08e2bfa8e5f7c662aca3f6560687fdc47");
+
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {new LTI3Request(req, ltiDataService, false, "1234", jwsClaims);}
+        );
+        verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_VERSION), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_NONCE), eq(String.class));
+        assertEquals("Nonce error: Unknown or already used nonce.", exception.getMessage());
+    }
+
+    @Test
+    public void testLTI3RequestWithValidNonce() {
+        when(req.getParameter("id_token")).thenReturn(ID_TOKEN);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class))).thenReturn(platformDeploymentList);
+        when(claims.getIssuer()).thenReturn(SAMPLE_ISS);
+        when(claims.getAudience()).thenReturn(SAMPLE_CLIENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_DEPLOYMENT_ID))).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(claims.get(eq(LtiStrings.LTI_VERSION), eq(String.class))).thenReturn(LtiStrings.LTI_VERSION_3);
+        when(claims.get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class))).thenReturn(LtiStrings.LTI_MESSAGE_TYPE_RESOURCE_LINK);
+        mockHttpSession.setAttribute("lti_nonce", Arrays.asList("5d04cb12f45df6ee373c42a1ca4cdbe08e2bfa8e5f7c662aca3f6560687fdc47"));
+        when(claims.get(eq(LtiStrings.LTI_NONCE), eq(String.class))).thenReturn("ba5938df7756a32ca3a4f89c40d88ff742651bc3ff417f6a4b7443f6f1e6a16c");
+
+        Assertions.assertThrows(NullPointerException.class, () -> {new LTI3Request(req, ltiDataService, false, "1234", jwsClaims);});
+
+        verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_VERSION), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_MESSAGE_TYPE), eq(String.class));
+        verify(claims).get(eq(LtiStrings.LTI_NONCE), eq(String.class));
+    }
+}

--- a/src/test/java/net/unicon/lti/utils/lti/LtiOidcUtilsTest.java
+++ b/src/test/java/net/unicon/lti/utils/lti/LtiOidcUtilsTest.java
@@ -75,7 +75,7 @@ public class LtiOidcUtilsTest {
             Map<String, String> authRequestMap = Collections.singletonMap("nonce", "nonce-value");
             topDateTimeUtilMock.when(() -> LocalDateTime.now(ZoneId.of("Z"))).thenReturn(currentLocalDate);
 
-            String state = LtiOidcUtils.generateState(ltiDataService, platformDeployment, authRequestMap, loginInitiationDTO, "client-id", "deployment-id");
+            String state = LtiOidcUtils.generateState(ltiDataService, authRequestMap, loginInitiationDTO, "client-id", "deployment-id");
 
             // validate that ltiToken was signed using private key and contains expected payload
             Jws<Claims> parsedLtiToken = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(state);


### PR DESCRIPTION
## Description
Moved validation of issuer, clientId, and deploymentId from OIDC request controller to LTI launch controller because the LTI 1.3 Core specification does not guarantee that the clientId or deploymentId will be available for validation until after the id_token has been retrieved.

### Motivation and Context
This change will allow a tool have multiple deployments associated with a single issuer and/or clientId without receiving a validation error.

### Fixes
[L3-68](https://lumenlearning.atlassian.net/browse/L3-68)

## How Has This Been Tested?
1. Ensure there is a functional Developer Key for the lti-middleware in Canvas.
2. Using the same client id from this Developer Key, deploy the lti-middleware to two separate Canvas courses and retrieve the deploymentId from each.
3. Perform a POST on the /config endpoint of the middleware for each deployment configuration.
4. Click on an LTI link in each of the two courses and ensure that the flow occurs as expected without encountering any error pages from the middleware.

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
