### PR TITLE
L3-67 add the ability to turn off the aws integration for local development environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,32 @@ Setup SQS for AGS Grade Pass Back
 2. The URI for a SQS queue should be filled in for either `lti13.grade-passback-queue` or as `LTI13_GRADE_PASSBACK_QUEUE` environment variable.
 3. The region of the SQS queue should be filled in for either `cloud.aws.region.static` in the application.properties file or `AWS_REGION` as an environment variable.
 
+Turning off AWS Integration for Local Development
+-------------------------------------------------
+Prior to running `mvn clean install spring-boot:run`, do the following:
+1. `export spring_profiles_active=no-aws`
+2. Ensure that the following property is present and uncommented in the application.properties file:
+`spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextInstanceDataAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextResourceLoaderAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration`
+
+Turning on AWS Integration for Local Development
+------------------------------------------------
+Prior to running `mvn clean install spring-boot:run`, do the following:
+1. `unset spring_profiles_active`
+2. Ensure that the following environment variables are set:
+```
+cloud.aws.region.static=us-west-1
+cloud.aws.region.auto=false
+cloud.aws.stack.auto=false
+lti13.grade-passback-queue=<queue name>
+cloud.aws.credentials.access-key=<access key>
+cloud.aws.credentials.secret-key=<secret key>
+cloud.aws.end-point.uri=<sqs uri>
+```
+
+Sample SQS Message for AGS/Grade Passback
+-----------------------------------------
+`{"client_id": "97140000000000230", "user_id": "4f3d12df-e1ae-484f-8b9a-b667864e8100", "deployment_id": "461:5440a08422ab1ee7794a0588b5e4cb4a094c4256", "issuer": "https://canvas.instructure.com", "lineitem_url": "https://canvas.unicon.net/api/lti/courses/3348/line_items/503", "score": 0.3}`
+
 Testing in the Dev/Staging Environment
 --------------------------------------
 1. Push changes to the branch that you want to push to the dev environment (e.g. L3-66-integration-testing)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Turning on AWS Integration for Local Development
 ------------------------------------------------
 Prior to running `mvn clean install spring-boot:run`, do the following:
 1. `unset spring_profiles_active`
-2. Ensure that the following environment variables are set:
+2. Ensure that the following properties are set in the application.properties file:
 ```
 cloud.aws.region.static=us-west-1
 cloud.aws.region.auto=false
@@ -159,6 +159,7 @@ cloud.aws.credentials.access-key=<access key>
 cloud.aws.credentials.secret-key=<secret key>
 cloud.aws.end-point.uri=<sqs uri>
 ```
+3. Ensure that the `spring.autoconfigure.exclude` property is commented out in the application.properties file.
 
 Sample SQS Message for AGS/Grade Passback
 -----------------------------------------

--- a/README.md
+++ b/README.md
@@ -142,14 +142,14 @@ Turning off AWS Integration for Local Development
 -------------------------------------------------
 Prior to running `mvn clean install spring-boot:run`, do the following:
 1. `export spring_profiles_active=no-aws`
-2. Ensure that the following property is present and uncommented in the application.properties file:
+2. Ensure that the following property is present and uncommented in the application-local.properties file (or application.properties, whichever is being used locally):
 `spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextInstanceDataAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextResourceLoaderAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration`
 
 Turning on AWS Integration for Local Development
 ------------------------------------------------
 Prior to running `mvn clean install spring-boot:run`, do the following:
 1. `unset spring_profiles_active`
-2. Ensure that the following properties are set in the application.properties file:
+2. Ensure that the following properties are set in the application-local.properties file (or application.properties, whichever is being used locally):
 ```
 cloud.aws.region.static=us-west-1
 cloud.aws.region.auto=false
@@ -159,7 +159,7 @@ cloud.aws.credentials.access-key=<access key>
 cloud.aws.credentials.secret-key=<secret key>
 cloud.aws.end-point.uri=<sqs uri>
 ```
-3. Ensure that the `spring.autoconfigure.exclude` property is commented out in the application.properties file.
+3. Ensure that the `spring.autoconfigure.exclude` property is commented out in the application-local.properties file (or application.properties, whichever is being used locally).
 
 Sample SQS Message for AGS/Grade Passback
 -----------------------------------------

--- a/src/main/java/net/unicon/lti/config/ApplicationConfig.java
+++ b/src/main/java/net/unicon/lti/config/ApplicationConfig.java
@@ -45,7 +45,7 @@ public class ApplicationConfig implements ApplicationContextAware {
     @PostConstruct
     public void init() {
         log.info("INIT");
-        env.setActiveProfiles("dev", "test");
+        env.setActiveProfiles("dev", "test", "no-aws");
         synchronized (configLock) {
             config = this;
         }

--- a/src/main/java/net/unicon/lti/service/sqs/impl/SQSMessageReceiver.java
+++ b/src/main/java/net/unicon/lti/service/sqs/impl/SQSMessageReceiver.java
@@ -22,6 +22,7 @@ import org.springframework.cloud.aws.messaging.listener.Acknowledgment;
 import org.springframework.cloud.aws.messaging.listener.SqsMessageDeletionPolicy;
 import org.springframework.cloud.aws.messaging.listener.Visibility;
 import org.springframework.cloud.aws.messaging.listener.annotation.SqsListener;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.Header;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Locale;
 
 @Slf4j
+@Profile("!no-aws")
 @Service
 @NoArgsConstructor
 public class SQSMessageReceiver {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -70,6 +70,7 @@ lti13.grade-passback-queue=dev-lti-service-grade-passback
 # spring.thymeleaf.cache=false
 # logging.level.org.springframework.security=DEBUG
 # spring.jpa.show-sql=true
+# spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextCredentialsAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextInstanceDataAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextResourceLoaderAutoConfiguration,org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration
 
 # #TO USE TOMCAT DIRECTLY WITH SSL (No apache proxy)
 # Only used in development

--- a/src/test/java/net/unicon/lti/service/sqs/test/SQSMessageReceiverTest.java
+++ b/src/test/java/net/unicon/lti/service/sqs/test/SQSMessageReceiverTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.cloud.aws.messaging.listener.Acknowledgment;
 import org.springframework.cloud.aws.messaging.listener.Visibility;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Profile("!no-aws")
 public class SQSMessageReceiverTest {
 
     @InjectMocks


### PR DESCRIPTION
## Description
I added relatively simple steps that can be taken to disable the AWS integration for local development environments.

### Motivation and Context
This solves the issue of developers needing valid AWS credentials and a valid SQS queue setup to be able to run the middleware locally (or else having to comment out large chunks of code).

### Fixes
[L3-67](https://lumenlearning.atlassian.net/browse/L3-67)

## How Has This Been Tested?
1. I commented out all of the `cloud.aws` properties in the properties file to remove my AWS credentials from my local setup.
2. I attempted to run `mvn clean install spring-boot:run` to start the local dev environment, and noticed the failure.
3. I followed the steps in the new README section titled "Turning off AWS Integration for Local Development" (Ran`export spring_profiles_active=no-aws` to set env var and uncommented `spring.autoconfigure.exclude` property).
4. I ran `mvn clean install spring-boot:run` to start the local dev environment and noticed that there was no longer build output regarding AWS. I confirmed that the LTI 1.3 standard launch flow still functioned in Canvas.
5. I followed the steps in the new README section titled "Turning on AWS Integration for Local Development" (Ran `unset spring_profiles_active` to remove the env var, commented out the `spring.autoconfigure.exclude` property, and uncommented the `cloud.aws` properties in the properties file).
6. I ran `mvn clean install spring-boot:run` to start the local dev environment and noticed that the AWS output has returned to the build logs and that the tomcat started successfully.
7. I used the "Sample SQS Message for AGS/Grade Passback" section of the README file to post a valid message to the SQS queue and confirmed that grade passback still functioned.

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
