### PR TITLE
L3-68 Fix bug that disallowed multiple deployments

### DIFF
--- a/src/main/java/net/unicon/lti/controller/lti/OIDCController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/OIDCController.java
@@ -96,7 +96,7 @@ public class OIDCController {
             return TextConstants.LTI3ERROR;
         }
         PlatformDeployment platformDeployment = platformDeploymentList.get(0);
-        if (platformDeploymentList.size() == 1 && clientIdValue == null || deploymentIdValue == null) {
+        if (platformDeploymentList.size() == 1 && (clientIdValue == null || deploymentIdValue == null)) {
             // If there is only one result, we know what the clientId and deploymentId will be
             if (clientIdValue == null) {
                 clientIdValue = platformDeployment.getClientId();

--- a/src/main/java/net/unicon/lti/utils/lti/LTI3Request.java
+++ b/src/main/java/net/unicon/lti/utils/lti/LTI3Request.java
@@ -560,7 +560,7 @@ public class LTI3Request {
             try {
                 return jws.getBody().get(mapToGet, Map.class);
             } catch (Exception ex) {
-                log.error("No map integer when expected in: {}. Returning null", mapToGet);
+                log.info("No map integer when expected in: {}. Returning null", mapToGet);
                 return new HashMap<>();
             }
         } else {

--- a/src/test/java/net/unicon/lti/controller/lti/OIDCControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/OIDCControllerTest.java
@@ -60,6 +60,7 @@ public class OIDCControllerTest {
     private static final String SAMPLE_ISS = "https://platform-lms.com";
     private static final String SAMPLE_CLIENT_ID = "sample-client-id";
     private static final String SAMPLE_DEPLOYMENT_ID = "sample-deployment-id";
+    private static final String SAMPLE_DEPLOYMENT_ID2 = "sample-deployment-id-2";
     private static final String SAMPLE_OIDC_ENDPOINT = "https://platform-lms.com/oidc";
     private static final String SAMPLE_ENCODED_REDIRECT_URI = "https%3A%2F%2Flti-tool.com%2Flti3%2F";
 
@@ -107,17 +108,13 @@ public class OIDCControllerTest {
         when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
         when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
         when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
-        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class)))
-                .thenReturn(onePlatformDeployment);
-        when(platformDeploymentRepository.findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID)))
-                .thenReturn(multiplePlatformDeployments);
-        when(platformDeploymentRepository.findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID)))
-                .thenReturn(onePlatformDeployment);
-        when(platformDeploymentRepository.findByIss(eq(SAMPLE_ISS)))
-                .thenReturn(multiplePlatformDeployments);
         when(ltiDataService.getDemoMode()).thenReturn(false);
         when(req.getSession()).thenReturn(mockHttpSession);
         when(ltiDataService.getLocalUrl()).thenReturn("https://lti-tool.com");
+        when(platformDeployment1.getClientId()).thenReturn(SAMPLE_CLIENT_ID);
+        when(platformDeployment2.getClientId()).thenReturn(SAMPLE_CLIENT_ID);
+        when(platformDeployment1.getDeploymentId()).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(platformDeployment2.getDeploymentId()).thenReturn(SAMPLE_DEPLOYMENT_ID2);
         when(platformDeployment1.getOidcEndpoint()).thenReturn(SAMPLE_OIDC_ENDPOINT);
         when(platformDeployment2.getOidcEndpoint()).thenReturn(SAMPLE_OIDC_ENDPOINT);
 
@@ -134,10 +131,15 @@ public class OIDCControllerTest {
     }
 
     @Test
-    public void testLoginInitiationWithIssuerAndClientIdAndDeploymentId() {
+    public void testLoginInitiationWithIssuerAndClientIdAndDeploymentIdOneConfig() {
         when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
         when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(SAMPLE_CLIENT_ID);
         when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class)))
+                .thenReturn(onePlatformDeployment);
 
         String response = oidcController.loginInitiations(req, res, model);
 
@@ -149,14 +151,43 @@ public class OIDCControllerTest {
         Mockito.verify(ltiDataService).getLocalUrl();
         Mockito.verify(ltiDataService).getOwnPrivateKey();
 
-        validateOAuthResponse(response, SAMPLE_CLIENT_ID);
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID, SAMPLE_DEPLOYMENT_ID, SAMPLE_ISS);
     }
 
     @Test
-    public void testLoginInitiationWithIssuerAndClientId() {
+    public void testLoginInitiationWithIssuerAndClientIdAndDeploymentIdMultipleConfigs() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(SAMPLE_CLIENT_ID);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class)))
+                .thenReturn(multiplePlatformDeployments);
+
+        String response = oidcController.loginInitiations(req, res, model);
+
+        Mockito.verify(platformDeploymentRepository).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID, SAMPLE_DEPLOYMENT_ID, SAMPLE_ISS);
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerAndClientIdOneConfig() {
         when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
         when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(SAMPLE_CLIENT_ID);
         when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID)))
+                .thenReturn(onePlatformDeployment);
 
         String response = oidcController.loginInitiations(req, res, model);
 
@@ -168,14 +199,43 @@ public class OIDCControllerTest {
         Mockito.verify(ltiDataService).getLocalUrl();
         Mockito.verify(ltiDataService).getOwnPrivateKey();
 
-        validateOAuthResponse(response, SAMPLE_CLIENT_ID);
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID, SAMPLE_DEPLOYMENT_ID, SAMPLE_ISS);
     }
 
     @Test
-    public void testLoginInitiationWithIssuer() {
+    public void testLoginInitiationWithIssuerAndClientIdMultipleConfigs() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(SAMPLE_CLIENT_ID);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID)))
+                .thenReturn(multiplePlatformDeployments);
+
+        String response = oidcController.loginInitiations(req, res, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID, null, SAMPLE_ISS);
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerOneConfig() {
         when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
         when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(null);
         when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIss(eq(SAMPLE_ISS)))
+                .thenReturn(onePlatformDeployment);
 
         String response = oidcController.loginInitiations(req, res, model);
 
@@ -187,15 +247,45 @@ public class OIDCControllerTest {
         Mockito.verify(ltiDataService).getLocalUrl();
         Mockito.verify(ltiDataService).getOwnPrivateKey();
 
-        validateOAuthResponse(response, null);
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID, SAMPLE_DEPLOYMENT_ID, SAMPLE_ISS);
 
     }
 
     @Test
-    public void testLoginInitiationWithIssuerAndDeploymentId() {
+    public void testLoginInitiationWithIssuerMultipleConfigs() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIss(eq(SAMPLE_ISS)))
+                .thenReturn(multiplePlatformDeployments);
+
+        String response = oidcController.loginInitiations(req, res, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, null, null, SAMPLE_ISS);
+
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerAndDeploymentIdOneConfig() {
         when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
         when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(null);
         when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID)))
+                .thenReturn(onePlatformDeployment);
 
         String response = oidcController.loginInitiations(req, res, model);
 
@@ -207,7 +297,32 @@ public class OIDCControllerTest {
         Mockito.verify(ltiDataService).getLocalUrl();
         Mockito.verify(ltiDataService).getOwnPrivateKey();
 
-        validateOAuthResponse(response, null);
+        validateOAuthResponse(response, SAMPLE_CLIENT_ID, SAMPLE_DEPLOYMENT_ID, SAMPLE_ISS);
+
+    }
+
+    @Test
+    public void testLoginInitiationWithIssuerAndDeploymentIdMultipleConfigs() {
+        when(req.getParameter(OIDC_ISS)).thenReturn(SAMPLE_ISS);
+        when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
+        when(platformDeploymentRepository.findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID)))
+                .thenReturn(multiplePlatformDeployments);
+
+        String response = oidcController.loginInitiations(req, res, model);
+
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientIdAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIssAndClientId(eq(SAMPLE_ISS), eq(SAMPLE_CLIENT_ID));
+        Mockito.verify(platformDeploymentRepository).findByIssAndDeploymentId(eq(SAMPLE_ISS), eq(SAMPLE_DEPLOYMENT_ID));
+        Mockito.verify(platformDeploymentRepository, never()).findByIss(eq(SAMPLE_ISS));
+        Mockito.verify(req).getSession();
+        Mockito.verify(ltiDataService).getLocalUrl();
+        Mockito.verify(ltiDataService).getOwnPrivateKey();
+
+        validateOAuthResponse(response, null, SAMPLE_DEPLOYMENT_ID, SAMPLE_ISS);
 
     }
 
@@ -216,6 +331,9 @@ public class OIDCControllerTest {
         when(req.getParameter(OIDC_ISS)).thenReturn(null);
         when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(null);
         when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(null);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
 
         String response = oidcController.loginInitiations(req, res, model);
 
@@ -235,6 +353,9 @@ public class OIDCControllerTest {
         when(req.getParameter(OIDC_ISS)).thenReturn(null);
         when(req.getParameter(OIDC_CLIENT_ID)).thenReturn(SAMPLE_CLIENT_ID);
         when(req.getParameter(OIDC_DEPLOYMENT_ID)).thenReturn(SAMPLE_DEPLOYMENT_ID);
+        when(req.getParameter(OIDC_TARGET_LINK_URI)).thenReturn(SAMPLE_TARGET_URI);
+        when(req.getParameter(OIDC_LTI_MESSAGE_HINT)).thenReturn(SAMPLE_LTI_MESSAGE_HINT);
+        when(req.getParameter(OIDC_LOGIN_HINT)).thenReturn(SAMPLE_LOGIN_HINT);
 
         String response = oidcController.loginInitiations(req, res, model);
 
@@ -249,7 +370,7 @@ public class OIDCControllerTest {
         assertEquals(TextConstants.LTI3ERROR, response);
     }
 
-    private void validateOAuthResponse(String response, String clientId) {
+    private void validateOAuthResponse(String response, String clientId, String deploymentId, String iss) {
         UriComponents responseUri = UriComponentsBuilder.fromUriString(response.substring("redirect:".length())).build();
         assertEquals(SAMPLE_OIDC_ENDPOINT, responseUri.getScheme() + "://" + responseUri.getHost() + responseUri.getPath());
         MultiValueMap<String, String> parameters = responseUri.getQueryParams();
@@ -269,5 +390,20 @@ public class OIDCControllerTest {
         assertTrue(parameters.get("nonce").get(0).length() >= 36);
         Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(parameters.get("state").get(0));
         assertNotNull(finalClaims);
+        assertEquals(TextConstants.DEFAULT_KID, finalClaims.getHeader().get("kid"));
+        assertEquals("JWT", finalClaims.getHeader().get("typ"));
+        assertEquals("ltiMiddleware", finalClaims.getBody().getIssuer());
+        assertEquals(clientId, finalClaims.getBody().getAudience());
+        assertNotNull(finalClaims.getBody().getExpiration());
+        assertNotNull(finalClaims.getBody().getNotBefore());
+        assertNotNull(finalClaims.getBody().getIssuedAt());
+        assertNotNull(finalClaims.getBody().getId());
+        assertEquals(iss, finalClaims.getBody().get("original_iss"));
+        assertEquals(SAMPLE_LOGIN_HINT, finalClaims.getBody().get("loginHint"));
+        assertEquals(SAMPLE_LTI_MESSAGE_HINT, finalClaims.getBody().get("ltiMessageHint"));
+        assertEquals(SAMPLE_TARGET_URI, finalClaims.getBody().get("targetLinkUri"));
+        assertEquals("/oidc/login_initiations", finalClaims.getBody().get("controller"));
+        assertEquals(clientId, finalClaims.getBody().get("clientId"));
+        assertEquals(deploymentId, finalClaims.getBody().get("ltiDeploymentId"));
     }
 }


### PR DESCRIPTION
## Description
Resolved issue where multiple deployments with the same clientId but different deploymentIds could not function simultaneously within Canvas. I also removed a red herring error from the logs regarding iframe size sometimes not being sent from the LMS in the id_token.

### Motivation and Context
This solution is necessary for the tool to be able to be added on the class level in multiple instances within Canvas instead of on the account level.

### Fixes
[L3-68](https://lumenlearning.atlassian.net/browse/L3-68)

## How Has This Been Tested?
1. Ensure that the tool does not exist in the Canvas instance on the account level because this will lead to that tool being prioritized over the class level tools and its deployment information will always be provided instead of the class level deployment information. This can be done by going to Admin > Settings > Apps > find the tool and click on the gear icon > Delete
2. Ensure that the account level deployment configuration has been deleted from the tool's database.
3. Deploy the tool within 3 different courses in Canvas with an individual deploymentId for each, but keeping the same clientId.
4. Use the /config/ endpoint to add each of these deployment configurations to the tool's database.
5. Try to use the tool in each of these 3 courses and confirm that the LTI flow can be completed.

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
