### PR TITLE
L3-81 fix ags token aud

### DIFF
--- a/src/main/java/net/unicon/lti/service/lti/impl/LTIJWTServiceImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/LTIJWTServiceImpl.java
@@ -136,7 +136,7 @@ public class LTIJWTServiceImpl implements LTIJWTService {
         Key toolPrivateKey = OAuthUtils.loadPrivateKey(ltiDataService.getOwnPrivateKey());
         String aud;
         //D2L needs a different aud, maybe others too
-        if (platformDeployment.getoAuth2TokenAud() != null) {
+        if (StringUtils.isNotBlank(platformDeployment.getoAuth2TokenAud())) {
             aud = platformDeployment.getoAuth2TokenAud();
         } else {
             aud = platformDeployment.getoAuth2TokenUrl();


### PR DESCRIPTION
## Description
The aud in the token request JWT was being improperly set due to only checking for null instead of checking for both null and blank strings for the aud value in the config database table. This led to valid SQS messages not getting the grades posted back to the LMS. (I suspect that Canvas didn't used to validate the aud in this JWT and that they recently pushed an update to validate it, which is why this worked previously but not now.)

### Motivation and Context
The fix for this solves the problem of valid SQS messages not resulting in grades being posted back to the LMS.

### Fixes
[L3-81](https://lumenlearning.atlassian.net/browse/L3-81

## How Has This Been Tested?
1. Send a valid SQS message to an SQS queue that is configured with the lti-middleware. For example: `{"client_id": "97140000000000230", "user_id": "4f3d12df-e1ae-484f-8b9a-b667864e8100", "deployment_id": "519:0a47de91cf84ee147f6e534195988508504d3e82", "issuer": "https://canvas.instructure.com", "lineitem_url": "https://canvas.unicon.net/api/lti/courses/3348/line_items/501", "score": 0.8}`
2. Ensure that the grade is posted to the LMS and that there are no errors in the logs from this process.

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
