### PR TITLE
L3-93 Switched from session storage to cookie storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.2</version>
+        <version>2.6.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>net.unicon</groupId>

--- a/src/main/java/net/unicon/lti/security/lti/LTI3OAuthProviderProcessingFilter.java
+++ b/src/main/java/net/unicon/lti/security/lti/LTI3OAuthProviderProcessingFilter.java
@@ -113,7 +113,7 @@ public class LTI3OAuthProviderProcessingFilter extends GenericFilterBean {
                 log.debug("State in cookie was {}", ltiStateCookie.get().getValue());
                 throw new IllegalStateException("LTI request doesn't contain the expected state");
             }
-            // Forth, we validate the state to be sure that is correct
+            // Fourth, we validate the state to be sure that is correct
             Jws<Claims> stateClaims = ltijwtService.validateState(state);
             if (stateClaims == null) {
                 throw new IllegalStateException("LTI state is invalid");

--- a/src/main/java/net/unicon/lti/utils/TextConstants.java
+++ b/src/main/java/net/unicon/lti/utils/TextConstants.java
@@ -22,6 +22,8 @@ public class TextConstants {
         throw new IllegalStateException("Utility class");
     }
 
+    public static final String LTI_STATE_COOKIE_NAME = "lti_state";
+    public static final String LTI_NONCE_COOKIE_NAME = "lti_nonce";
     public static final String TOKEN = "Token - ";
     public static final String NO_SESSION_VALUES = "noSessionValues";
     public static final String SINGLE = "single";

--- a/src/test/java/net/unicon/lti/security/lti/LTI3OAuthProviderProcessingFilterTest.java
+++ b/src/test/java/net/unicon/lti/security/lti/LTI3OAuthProviderProcessingFilterTest.java
@@ -1,0 +1,155 @@
+package net.unicon.lti.security.lti;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import net.unicon.lti.model.lti.dto.LoginInitiationDTO;
+import net.unicon.lti.service.lti.LTIDataService;
+import net.unicon.lti.service.lti.LTIJWTService;
+import net.unicon.lti.utils.lti.LtiOidcUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.Cookie;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Collections;
+
+import static net.unicon.lti.utils.TextConstants.LTI_NONCE_COOKIE_NAME;
+import static net.unicon.lti.utils.TextConstants.LTI_STATE_COOKIE_NAME;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+public class LTI3OAuthProviderProcessingFilterTest {
+    private static final String TEST_STATE = "test-state";
+    private static final Cookie NONCE_COOKIE = new Cookie(LTI_NONCE_COOKIE_NAME, "nonce-value");
+    private static final Cookie JSESSIONID_COOKIE = new Cookie("JSESSIONID", "test");
+
+    private LTI3OAuthProviderProcessingFilter lti3OAuthFilter;
+
+    @Mock
+    private LTIDataService ltiDataService;
+
+    @Mock
+    private LTIJWTService ltijwtService;
+
+    @Mock
+    FilterChain mockChain;
+
+    @Mock
+    private ServletRequest servletRequest;
+
+    @Mock
+    LoginInitiationDTO loginInitiationDTO;
+
+    private MockHttpServletRequest req = new MockHttpServletRequest();
+
+    private MockHttpServletResponse res = new MockHttpServletResponse();
+
+    private KeyPair kp;
+
+    @BeforeEach()
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        lti3OAuthFilter = new LTI3OAuthProviderProcessingFilter(ltiDataService, ltijwtService);
+    }
+
+    @Test
+    public void testDoFilterWithoutHttpServletRequest() {
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {lti3OAuthFilter.doFilter(servletRequest, res, mockChain);}
+        );
+        assertEquals("LTI request MUST be an HttpServletRequest (cannot only be a ServletRequest)", exception.getMessage());
+    }
+
+    @Test
+    public void testDoFilterWithoutCookies() {
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {lti3OAuthFilter.doFilter(req, res, mockChain);}
+        );
+        assertEquals("LTI request doesn't contain any cookies", exception.getMessage());
+    }
+
+    @Test
+    public void testDoFilterWithEmptyStateCookie() {
+        Cookie[] cookies = {NONCE_COOKIE, JSESSIONID_COOKIE};
+        req.setCookies(cookies);
+
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {lti3OAuthFilter.doFilter(req, res, mockChain);}
+        );
+        assertEquals("LTI state could not be found", exception.getMessage());
+    }
+
+    @Test
+    public void testDoFilterWithStateCookieThatDoesNotMatchRequest() {
+        Cookie[] cookies = {NONCE_COOKIE, JSESSIONID_COOKIE, new Cookie(LTI_STATE_COOKIE_NAME, TEST_STATE)};
+        req.setCookies(cookies);
+        req.setParameter("state", "different-test-state");
+
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {lti3OAuthFilter.doFilter(req, res, mockChain);}
+        );
+        assertEquals("LTI request doesn't contain the expected state", exception.getMessage());
+    }
+
+    @Test
+    public void testDoFilterWithInvalidState() {
+        Cookie[] cookies = {NONCE_COOKIE, JSESSIONID_COOKIE, new Cookie(LTI_STATE_COOKIE_NAME, TEST_STATE)};
+        req.setCookies(cookies);
+        req.setParameter("state", TEST_STATE);
+
+        IllegalStateException exception = Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> {lti3OAuthFilter.doFilter(req, res, mockChain);}
+        );
+
+        assertEquals("LTI state is invalid", exception.getMessage());
+        Mockito.verify(ltijwtService).validateState(eq(TEST_STATE));
+    }
+
+    @Test
+    public void testDoFilterWithValidState() {
+        try {
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+            kpg.initialize(1024);
+            kp = kpg.generateKeyPair();
+            Base64.Encoder encoder = Base64.getEncoder();
+            String privateKey = "-----BEGIN PRIVATE KEY-----\n" + encoder.encodeToString(kp.getPrivate().getEncoded()) + "\n-----END PRIVATE KEY-----\n";
+            when(ltiDataService.getOwnPrivateKey()).thenReturn(privateKey);
+            String validState = LtiOidcUtils.generateState(ltiDataService, Collections.singletonMap("nonce", "nonce-value"), loginInitiationDTO, "client-id", "deployment-id");
+            Cookie[] cookies = {NONCE_COOKIE, JSESSIONID_COOKIE, new Cookie(LTI_STATE_COOKIE_NAME, validState)};
+            req.setCookies(cookies);
+            req.setParameter("state", validState);
+            Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(validState);
+            when(ltijwtService.validateState(validState)).thenReturn(finalClaims);
+
+            lti3OAuthFilter.doFilter(req, res, mockChain);
+
+            Mockito.verify(ltijwtService).validateState(eq(validState));
+            Mockito.verify(mockChain).doFilter(eq(req), eq(res));
+
+        } catch (GeneralSecurityException | IOException | ServletException e) {
+            fail();
+        }
+
+    }
+}


### PR DESCRIPTION
## Description
I switched from session storage to cookie storage for the state and nonce used to do the LTI Core authentication process. I also bumped the Spring version in light of the latest vulnerability (though this is simply precautionary as I believe either Spring MVC or Spring WebFlux is used in this project).

### Motivation and Context
Switching from session storage to cookie storage will hopefully allow for having multiple instances of the middleware running without having to utilize sticky sessions. By storing the state and nonce in cookies in the user's browser, they remain tied to the user's browser without being tied to the session storage of a specific instance of the middleware.

### Fixes
[L3-93](https://lumenlearning.atlassian.net/browse/L3-93)

## How Has This Been Tested?
1. Run the middleware with demo mode off.
2. Log into Canvas and click on a Waymaker link with the developer tools open.
3. Note that the link works as expected and that the LTI 1.3 handshake took place in the developer tools (/oidc/login_initiations and /lti3 endpoints were successfully hit).
4. Note that there are no unexpected errors in the middleware logs.
5. Run the middleware with demo mode on.
6. Log into Canvas and click on a Waymaker link with the developer tools open.
7. When it stops after the /oidc/login_initiations request, alter or delete the lti_state cookie.
8. Click to go on to the second step.
9. Note that the error page displays and that there is an error in the logs.
10. Click on a Waymaker link with the developer tools open again.
11. When it stops after the /oidc/login_initiations request, alter or delete the lti_nonce cookie.
12. Click to go on to the next step.
13. Note that the error page displays and that there is an error in the logs.

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
