### PR TITLE
L3 93 ops changes for larger headers to set cookies

### DIFF
--- a/.platform/00_nginx.config
+++ b/.platform/00_nginx.config
@@ -1,0 +1,3 @@
+container_commands:
+  01_reload_nginx:
+    command: "service nginx reload"

--- a/.platform/nginx/conf.d/proxy.conf
+++ b/.platform/nginx/conf.d/proxy.conf
@@ -1,0 +1,2 @@
+proxy_buffers         8 32k;
+proxy_buffer_size     32k;

--- a/deploy/docker_beanstalk_deploy.sh
+++ b/deploy/docker_beanstalk_deploy.sh
@@ -101,7 +101,7 @@ docker push \
 #
 
 DOCKERRUN_FILENAME="Dockerrun.aws.${AWS_ECR_IMAGE_TAG}.json"
-
+ZIP_FILE_NAME="lti-service-beanstalk-${AWS_ECR_IMAGE_TAG}.zip"
 
 echo -e "\n============================================================"
 echo "  Creating Dockerrun.aws.json file"
@@ -112,19 +112,23 @@ sed -i "s/AWS_ACCOUNT_ID/${AWS_ACCOUNT_NUMBER}/" "$DOCKERRUN_FILENAME"
 sed -i "s/ECR_IMAGE_TAG/${AWS_ECR_IMAGE_TAG}/" "$DOCKERRUN_FILENAME"
 cat "$DOCKERRUN_FILENAME"
 
+echo -e "\n============================================================"
+echo "  Creating beankstalk zip archive"
+echo -e "============================================================\n"
+zip "$ZIP_FILE_NAME" -r $DOCKERRUN_FILENAME .platform/ 
+
 
 echo -e "\n============================================================"
 echo "  Uploading to S3: $DOCKERRUN_FILENAME -> s3://${S3_BUCKET_NAME}"
 echo -e "============================================================\n"
 
-aws s3 cp "$DOCKERRUN_FILENAME" "s3://${S3_BUCKET_NAME}/"
-
+aws s3 cp "$ZIP_FILE_NAME" "s3://${S3_BUCKET_NAME}/"
 
 echo -e "\n============================================================"
 echo "  Creating application version"
 echo -e "============================================================\n"
 
-aws elasticbeanstalk create-application-version --region us-west-2 --application-name "$BEANSTALK_APPLICATION" --version-label "$AWS_ECR_IMAGE_TAG" --description "Git commit $TRAVIS_COMMIT" --source-bundle S3Bucket="$S3_BUCKET_NAME",S3Key="$DOCKERRUN_FILENAME"
+aws elasticbeanstalk create-application-version --region us-west-2 --application-name "$BEANSTALK_APPLICATION" --version-label "$AWS_ECR_IMAGE_TAG" --description "Git commit $TRAVIS_COMMIT" --source-bundle S3Bucket="$S3_BUCKET_NAME",S3Key="$ZIP_FILE_NAME"
 
 
 echo -e "\n============================================================"

--- a/deploy/docker_beanstalk_deploy.sh
+++ b/deploy/docker_beanstalk_deploy.sh
@@ -100,7 +100,7 @@ docker push \
 #   4. Update a Beanstalk environment with that app version.
 #
 
-DOCKERRUN_FILENAME="Dockerrun.aws.${AWS_ECR_IMAGE_TAG}.json"
+DOCKERRUN_FILENAME="Dockerrun.aws.json"
 ZIP_FILE_NAME="lti-service-beanstalk-${AWS_ECR_IMAGE_TAG}.zip"
 
 echo -e "\n============================================================"


### PR DESCRIPTION
## Description
AWS configuration was updated to allow for larger headers to be able to set the state cookie.

### Motivation and Context
This change was required so that the state and nonce could switch to being stored in cookies rather than in the Java session, which would have required sticky sessions.

### Fixes
[L3-93](https://lumenlearning.atlassian.net/browse/L3-93)

## How Has This Been Tested?
1. Log into a Canvas instance with the Lumen tool configured for the dev environment and navigate to a course with a cartridge for the dev environment.
2. Click on one of the links from the cartridge with the Network tab of the dev tools open.
3. Note that the LTI handshake completes without any 502 Bad Gateway errors occurring.

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
