### PR TITLE
Fix AGS demo for Moodle

### DIFF
--- a/src/main/java/net/unicon/lti/service/lti/AdvantageConnectorHelper.java
+++ b/src/main/java/net/unicon/lti/service/lti/AdvantageConnectorHelper.java
@@ -19,6 +19,8 @@ public interface AdvantageConnectorHelper {
     // We put the token in the Authorization as a simple Bearer one.
     HttpEntity<LineItem> createTokenizedRequestEntity(LTIToken LTIToken, LineItem lineItem, String type);
 
+    HttpEntity<LineItem> createTokenizedRequestEntity(LTIToken LTIToken, String type);
+
     // We put the token in the Authorization as a simple Bearer one.
     HttpEntity<LineItems> createTokenizedRequestEntity(LTIToken LTIToken, LineItems lineItems);
 

--- a/src/main/java/net/unicon/lti/utils/TextConstants.java
+++ b/src/main/java/net/unicon/lti/utils/TextConstants.java
@@ -40,6 +40,8 @@ public class TextConstants {
     public static final String NOT_ENOUGH_PERMISSIONS = "Error 104: Not enough permissions to access to this endpoint.";
     public static final String BAD_TOKEN = "The token does not contain the expected information";
     public static final String LINEITEM_TYPE = "application/vnd.ims.lis.v2.lineitem+json";
+    public static final String ALL_LINEITEMS_TYPE = "application/vnd.ims.lis.v2.lineitemcontainer+json";
+    public static final String RESULTS_TYPE = "application/vnd.ims.lis.v2.resultcontainer+json";
 
 
 }

--- a/src/main/resources/templates/ltiAdvAgsMain.html
+++ b/src/main/resources/templates/ltiAdvAgsMain.html
@@ -18,7 +18,7 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.thymeleaf.org "
       xml:lang="en">
 <head>
-    <title>LTI 3 </title>
+    <title>LTI 1.3 AGS Demo</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link rel="stylesheet" type="text/css" th:href="@{/css/bootstrap.min.css}"/>
     <link rel="stylesheet" type="text/css" th:href="@{/css/style.css}"/>
@@ -129,8 +129,8 @@
         </thead>
         <tbody>
         <tr th:each="lineitem,rowStat : ${lineitems}">
-            <td><a th:href="@{/ags/delete/{did}(did=${#strings.arraySplit(lineitem.id,'/')[#arrays.length(#strings.arraySplit(lineitem.id, '/')) - 1]})}">Delete</a></td>
-            <td><a th:href="@{/ags/{did}(did=${#strings.arraySplit(lineitem.id,'/')[#arrays.length(#strings.arraySplit(lineitem.id, '/')) - 1]})}">Detail</a></td>
+            <td th:with="idLocator=${#strings.contains(lineitem.id, '?') ? 2 : 1}"><a th:href="@{/ags/delete/{did}(did=${#strings.arraySplit(lineitem.id,'/')[#arrays.length(#strings.arraySplit(lineitem.id, '/')) - idLocator]})}">Delete</a></td>
+            <td th:with="idLocator=${#strings.contains(lineitem.id, '?') ? 2 : 1}"><a th:href="@{/ags/{did}(did=${#strings.arraySplit(lineitem.id,'/')[#arrays.length(#strings.arraySplit(lineitem.id, '/')) - idLocator]})}">Detail</a></td>
             <td th:text="${rowStat.count}">1</td>
             <td th:text="${lineitem.id}"></td>
             <td th:text="${lineitem.scoreMaximum}"></td>


### PR DESCRIPTION
## Description
Ensure that the AGS demo functions in Moodle, D2L, and Canvas. This addresses the issue of Moodle returning JSON Bearer tokens with a content type of "text/html" as well as the issue of Moodle's lineitems URLs containing request parameters, unlike the rest of the LMSs.

### Motivation and Context
These changes will allow for quicker experimentation with the AGS service for the "Deep Linking" effort.

### Fixes
[DL3-12](https://lumenlearning.atlassian.net/browse/DL3-12)

## How Has This Been Tested?
For each Moodle, D2L, and Canvas, do the following:
0. Ensure that the middleware is registered in the LMS and that there is a link within the LMS to access it. Ensure that both the demo mode and AGS features are turned on in the Middleware's `application.properties` file.
1. In the LMS, click on the link to the middleware.
2. Click the button to "Perform GET as Step 2".
3. Click on the "Click here to see the lineitems on this course using the LTI Adv AGS service" link.
4. Ensure that the LTI 1.3 AGS Demo page loads without error.
5. Enter a value for the "Label".
6. Enter a number for the "ScoreMaximum".
7. Click the "Create New LineItem" button.
8. Ensure that the page reloads indicating that the new line item was created.
9. Click on the "Details" link for the new line item to view it on the Details demo page.
10. Go to the LMS grade book and confirm that your new line item is present there as well.

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
