### PR TITLE
DL3-32 - Remove References to Waymaker from the UI Text

### DIFF
--- a/src/main/frontend/src/features/CoursePicker.js
+++ b/src/main/frontend/src/features/CoursePicker.js
@@ -19,7 +19,7 @@ function CoursePicker (props) {
       <div className="header">
         <Row>
           <Col sm={8}>
-            <Header header="Add a Waymaker Course" subheader="Select the Waymaker course you would like to add" />
+            <Header header="Add a Course" subheader="Select the course you would like to add" />
           </Col>
           <Col sm={4}>
             <SearchInput />

--- a/src/main/frontend/src/features/LtiBreadcrumb.js
+++ b/src/main/frontend/src/features/LtiBreadcrumb.js
@@ -16,7 +16,6 @@ function LtiBreadcrumb(props) {
 
   return (
     <Breadcrumb role="navigation">
-      <Breadcrumb.Item onClick={(e) => resetSelectedCourse()}>Waymaker</Breadcrumb.Item>
       <Breadcrumb.Item active={!selectedCourse} onClick={(e) => resetSelectedCourse()}>Add Course</Breadcrumb.Item>
       {selectedCourse && <Breadcrumb.Item active>{selectedCourse.book_title}</Breadcrumb.Item>}
     </Breadcrumb>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including your Jira ticket ID. -->

## Description
Remove References to Waymaker from the UI Text

### Motivation and Context
Remove References to Waymaker from the UI Text

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/DL3-32)

## How Has This Been Tested?
- Tested in the UI
- Searched the Waymaker string across all the source and it's not present in the UI anymore.

## Screenshots

![a](https://user-images.githubusercontent.com/8653754/175934436-fd5ca755-2e79-4f8d-bfa8-dac5e2f4e1af.jpg)
![b](https://user-images.githubusercontent.com/8653754/175934439-6bec2cad-297e-4254-b3f9-b61f74a53f29.jpg)


---
<!-- The following section calls out any changes that will impact the deploy of this PR and/or need to be shared with the team post-deploy. It is not meant to be all-inclusive; if there are additional things to note here, make a heading and do so :) -->

## Database changes
<!-- Describe any database changes here. -->

## ⚠️ Deployment instructions ⚠️
<!-- Make note of any unique-to-this-PR deployment instructions here. -->

## New ENV variables
<!-- Document any new ENV variables added as part of this work -->

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the AC for this feature and my changes meet all requirements
- [X] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have requested a review from at least one other dev
