### PR TITLE
DL3-34 fix HarmonyServiceTest

### DIFF
--- a/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
@@ -1,149 +1,164 @@
 package net.unicon.lti.service.harmony;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.mockserver.model.HttpRequest.request;
-import static org.mockserver.model.HttpResponse.response;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockserver.junit.jupiter.MockServerExtension;
-import org.mockserver.integration.ClientAndServer;
-import org.mockserver.junit.jupiter.MockServerSettings;
-import org.mockserver.model.MediaType;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.util.ReflectionTestUtils;
-
+import net.unicon.lti.model.harmony.HarmonyCourse;
+import net.unicon.lti.model.harmony.HarmonyMetadata;
+import net.unicon.lti.model.harmony.HarmonyMetadataLinks;
 import net.unicon.lti.model.harmony.HarmonyPageResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mock.http.MockHttpInputMessage;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
 
-@ExtendWith(MockServerExtension.class)
-@MockServerSettings(ports = {1080, 1081})
-@SpringBootTest
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
 public class HarmonyServiceTest {
 
     private final String MOCK_SERVER_URL = "http://localhost:1080";
 
-    @Autowired
+    @InjectMocks
     private HarmonyService harmonyService;
 
-    private final ClientAndServer client;
+    @Mock
+    private RestTemplate restTemplate;
 
-    public HarmonyServiceTest(ClientAndServer client) {
-        this.client = client;
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
     }
 
     @Test
     public void testNullCredentials() {
         ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", null);
         ReflectionTestUtils.setField(harmonyService, "harmonyJWT", null);
-        assertEquals(harmonyService.fetchHarmonyCourses(), null);
+        assertNull(harmonyService.fetchHarmonyCourses());
     }
 
     @Test
     public void testEmptyCredentials() {
         ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "");
         ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "");
-        assertEquals(harmonyService.fetchHarmonyCourses(), null);
+        assertNull(harmonyService.fetchHarmonyCourses());
     }
 
     @Test
     public void testNullUrl() {
         ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", null);
         ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
-        assertEquals(harmonyService.fetchHarmonyCourses(), null);
+        assertNull(harmonyService.fetchHarmonyCourses());
     }
 
     @Test
     public void testNullToken() {
         ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "nonnull");
         ReflectionTestUtils.setField(harmonyService, "harmonyJWT", null);
-        assertEquals(harmonyService.fetchHarmonyCourses(), null);
+        assertNull(harmonyService.fetchHarmonyCourses());
     }
 
     @Test
     public void testEmptyUrl() {
         ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "");
         ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
-        assertEquals(harmonyService.fetchHarmonyCourses(), null);
+        assertNull(harmonyService.fetchHarmonyCourses());
     }
 
     @Test
     public void testEmptyToken() {
         ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "nonnull");
         ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "");
-        assertEquals(harmonyService.fetchHarmonyCourses(), null);
+        assertNull(harmonyService.fetchHarmonyCourses());
     }
 
     @Test
     public void testNotValidURL() {
         ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "notvalid");
         ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
-        assertEquals(harmonyService.fetchHarmonyCourses(), null);
+        ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
+        when(restTemplate.exchange(eq("notvalid"), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
+        assertNull(harmonyService.fetchHarmonyCourses());
     }
 
     @Test
     public void testForbiddenRequest() {
-        client.reset();
-        client
-           .when(request().withMethod("GET"))
-           .respond(response().withStatusCode(401));
         ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
         ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
-        assertEquals(harmonyService.fetchHarmonyCourses(), null);
+
+        ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.FORBIDDEN);
+        when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
+
+        assertNull(harmonyService.fetchHarmonyCourses());
     }
 
     @Test
     public void testBadRequest() {
-        client.reset();
-        client
-            .when(request().withMethod("GET"))
-            .respond(response().withStatusCode(400));
         ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
         ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
-        assertEquals(harmonyService.fetchHarmonyCourses(), null);
+
+        ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
+        when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
+
+        assertNull(harmonyService.fetchHarmonyCourses());
     }
 
     @Test
     public void testWrongResponse() {
-        String jsonResponse = "[{\"not\": \"root\",\"valid\": \"Root\",\"schema\": null}]";
-        client.reset();
-        client
-            .when(request().withMethod("GET"))
-            .respond(response()
-                .withStatusCode(200)
-                .withContentType(MediaType.APPLICATION_JSON)
-                .withBody(jsonResponse));
         ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
         ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
-        HarmonyPageResponse harmonyResponse = harmonyService.fetchHarmonyCourses();  
-        assertEquals(harmonyResponse, null);
+
+        when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenThrow(new HttpMessageNotReadableException("JSON not able to be parsed", new MockHttpInputMessage("[{\"not\": \"root\",\"valid\": \"Root\",\"schema\": null}]".getBytes(StandardCharsets.UTF_8))));
+        assertNull(harmonyService.fetchHarmonyCourses());
     }
 
     @Test
     public void testGoodResponse() {
-        String jsonResponse = "{\"records\":[{\"root_outcome_guid\":\"root\",\"book_title\":\"Root\",\"release_date\":null,\"cover_img_url\":null,\"category\":null,\"description\":null,\"table_of_contents\":{}}],\"metadata\":{\"page\":\"1\",\"per_page\":\"10\",\"page_count\":1,\"total_count\":1,\"links\":{\"first\":\"/service_api/course_catalog?page=1\",\"last\":\"/service_api/course_catalog?page=1\"}}}";
-        client.reset();
-        client
-            .when(request().withMethod("GET"))
-            .respond(response()
-                .withStatusCode(200)
-                .withContentType(MediaType.APPLICATION_JSON)
-                .withBody(jsonResponse));
         ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
         ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
-        HarmonyPageResponse harmonyResponse = harmonyService.fetchHarmonyCourses(); 
-        assertNotEquals(harmonyResponse, null);
-        assertEquals(harmonyResponse.getRecords().size(), 1);
-        assertEquals(harmonyResponse.getRecords().get(0).getRoot_outcome_guid(), "root");
-        assertEquals(harmonyResponse.getRecords().get(0).getBook_title(), "Root");
-        assertEquals(harmonyResponse.getMetadata().getPage(), "1");
-        assertEquals(harmonyResponse.getMetadata().getPage_count(), 1);
-        assertEquals(harmonyResponse.getMetadata().getTotal_count(), 1);
-        assertEquals(harmonyResponse.getMetadata().getPer_page(), "10");
-        assertNotEquals(harmonyResponse.getMetadata().getLinks().getFirst(), null);
-        assertNotEquals(harmonyResponse.getMetadata().getLinks().getFirst(), null);
+
+        HarmonyCourse harmonyCourse = new HarmonyCourse();
+        harmonyCourse.setRoot_outcome_guid("root");
+        harmonyCourse.setBook_title("Root");
+        HarmonyMetadata harmonyMetadata = new HarmonyMetadata();
+        harmonyMetadata.setPage("1");
+        harmonyMetadata.setPer_page("10");
+        harmonyMetadata.setPage_count(1);
+        harmonyMetadata.setTotal_count(1);
+        HarmonyMetadataLinks harmonyMetadataLinks = new HarmonyMetadataLinks();
+        harmonyMetadataLinks.setFirst("/service_api/course_catalog?page=1");
+        harmonyMetadataLinks.setLast("/service_api/course_catalog?page=1");
+        harmonyMetadata.setLinks(harmonyMetadataLinks);
+        HarmonyPageResponse harmonyPageResponse = new HarmonyPageResponse();
+        harmonyPageResponse.setRecords(List.of(harmonyCourse));
+        harmonyPageResponse.setMetadata(harmonyMetadata);
+        ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(harmonyPageResponse, HttpStatus.OK);
+        when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
+
+        HarmonyPageResponse serviceResponse = harmonyService.fetchHarmonyCourses();
+        assertNotNull(serviceResponse);
+        assertEquals(serviceResponse.getRecords().size(), 1);
+        assertEquals(serviceResponse.getRecords().get(0).getRoot_outcome_guid(), "root");
+        assertEquals(serviceResponse.getRecords().get(0).getBook_title(), "Root");
+        assertEquals(serviceResponse.getMetadata().getPage(), "1");
+        assertEquals(serviceResponse.getMetadata().getPage_count(), 1);
+        assertEquals(serviceResponse.getMetadata().getTotal_count(), 1);
+        assertEquals(serviceResponse.getMetadata().getPer_page(), "10");
+        assertNotNull(serviceResponse.getMetadata().getLinks().getFirst());
+        assertNotNull(serviceResponse.getMetadata().getLinks().getFirst());
     }
 
 }


### PR DESCRIPTION
## Description
Uses mocks instead of running a server during unit tests

### Motivation and Context
The test was broken so the code would not compile without fixing the test.

### Fixes
[DL3-34](https://lumenlearning.atlassian.net/browse/DL3-34)

## How Has This Been Tested?
I ran `mvn clean install` to confirm that all unit tests worked and the code compiled correctly.

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
