### PR TITLE
DL3-51 Send id_token and course_paired=false by default when fetching deep links from harmony

### DIFF
--- a/src/main/java/net/unicon/lti/controller/lti/LtiContextController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LtiContextController.java
@@ -68,7 +68,7 @@ public class LtiContextController {
             // Update context to have rootOutcomeGuid value
             if (ltiContext != null) {
                 // Retrieve and validate links from Harmony
-                List<HarmonyContentItemDTO> harmonyContentItems = harmonyService.fetchDeepLinkingContentItems(rootOutcomeGuid, lti3Request.getLtiToolPlatformGuid());
+                List<HarmonyContentItemDTO> harmonyContentItems = harmonyService.fetchDeepLinkingContentItems(rootOutcomeGuid, lti3Request.getLtiToolPlatformGuid(), idToken);
 
                 // Generate Deep Link Response JWT
                 if (harmonyContentItems != null && !harmonyContentItems.isEmpty()) {

--- a/src/test/java/net/unicon/lti/controller/lti/LtiContextControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/LtiContextControllerTest.java
@@ -123,7 +123,7 @@ public class LtiContextControllerTest {
                 .thenReturn(List.of(platformDeployment));
         when(ltiContextRepository.findByContextKeyAndPlatformDeployment(eq(SAMPLE_CONTEXT_ID), eq(platformDeployment))).thenReturn(ltiContextEntity);
         when(lti3Request.getLtiToolPlatformGuid()).thenReturn(SAMPLE_LTI_TOOL_PLATFORM_GUID);
-        when(harmonyService.fetchDeepLinkingContentItems(eq(SAMPLE_ROOT_OUTCOME_GUID), eq(SAMPLE_LTI_TOOL_PLATFORM_GUID))).thenReturn(new ArrayList<>());
+        when(harmonyService.fetchDeepLinkingContentItems(eq(SAMPLE_ROOT_OUTCOME_GUID), eq(SAMPLE_LTI_TOOL_PLATFORM_GUID), eq(SAMPLE_DL_ID_TOKEN))).thenReturn(new ArrayList<>());
 
         ResponseEntity<Object> response = ltiContextController.pairBookToLMSContext(pairBookBody);
 
@@ -142,7 +142,7 @@ public class LtiContextControllerTest {
                 .thenReturn(List.of(platformDeployment));
         when(ltiContextRepository.findByContextKeyAndPlatformDeployment(eq(SAMPLE_CONTEXT_ID), eq(platformDeployment))).thenReturn(ltiContextEntity);
         when(lti3Request.getLtiToolPlatformGuid()).thenReturn(SAMPLE_LTI_TOOL_PLATFORM_GUID);
-        when(harmonyService.fetchDeepLinkingContentItems(eq(SAMPLE_ROOT_OUTCOME_GUID), eq(SAMPLE_LTI_TOOL_PLATFORM_GUID))).thenReturn(null);
+        when(harmonyService.fetchDeepLinkingContentItems(eq(SAMPLE_ROOT_OUTCOME_GUID), eq(SAMPLE_LTI_TOOL_PLATFORM_GUID), eq(SAMPLE_DL_ID_TOKEN))).thenReturn(null);
 
         ResponseEntity<Object> response = ltiContextController.pairBookToLMSContext(pairBookBody);
 
@@ -162,7 +162,7 @@ public class LtiContextControllerTest {
         when(ltiContextRepository.findByContextKeyAndPlatformDeployment(eq(SAMPLE_CONTEXT_ID), eq(platformDeployment))).thenReturn(ltiContextEntity);
         when(lti3Request.getLtiToolPlatformGuid()).thenReturn(SAMPLE_LTI_TOOL_PLATFORM_GUID);
         List<HarmonyContentItemDTO> contentItems = generateDeepLinkingContentItemsList();
-        when(harmonyService.fetchDeepLinkingContentItems(eq(SAMPLE_ROOT_OUTCOME_GUID), eq(SAMPLE_LTI_TOOL_PLATFORM_GUID))).thenReturn(contentItems);
+        when(harmonyService.fetchDeepLinkingContentItems(eq(SAMPLE_ROOT_OUTCOME_GUID), eq(SAMPLE_LTI_TOOL_PLATFORM_GUID), eq(SAMPLE_DL_ID_TOKEN))).thenReturn(contentItems);
         deepLinkUtilsMockedStatic.when(() -> DeepLinkUtils.generateDeepLinkingResponseJWT(eq(ltiDataService), eq(lti3Request), anyList())).thenThrow(GeneralSecurityException.class);
 
         ResponseEntity<Object> response = ltiContextController.pairBookToLMSContext(pairBookBody);
@@ -183,7 +183,7 @@ public class LtiContextControllerTest {
         when(ltiContextRepository.findByContextKeyAndPlatformDeployment(eq(SAMPLE_CONTEXT_ID), eq(platformDeployment))).thenReturn(ltiContextEntity);
         when(lti3Request.getLtiToolPlatformGuid()).thenReturn(SAMPLE_LTI_TOOL_PLATFORM_GUID);
         List<HarmonyContentItemDTO> contentItems = generateDeepLinkingContentItemsList();
-        when(harmonyService.fetchDeepLinkingContentItems(eq(SAMPLE_ROOT_OUTCOME_GUID), eq(SAMPLE_LTI_TOOL_PLATFORM_GUID))).thenReturn(contentItems);
+        when(harmonyService.fetchDeepLinkingContentItems(eq(SAMPLE_ROOT_OUTCOME_GUID), eq(SAMPLE_LTI_TOOL_PLATFORM_GUID), eq(SAMPLE_DL_ID_TOKEN))).thenReturn(contentItems);
         deepLinkUtilsMockedStatic.when(() -> DeepLinkUtils.generateDeepLinkingResponseJWT(eq(ltiDataService), eq(lti3Request), anyList())).thenReturn("deep-linking-response-jwt");
         when(lti3Request.getDeepLinkReturnUrl()).thenReturn("https://lms.com/deep-link-return");
 

--- a/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
@@ -7,6 +7,7 @@ import net.unicon.lti.model.harmony.HarmonyPageResponse;
 import net.unicon.lti.model.harmony.HarmonyContentItemDTO;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -21,6 +22,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -31,10 +33,13 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 public class HarmonyServiceTest {
-
     private final String MOCK_SERVER_URL = "http://localhost:1080";
+    private final String MOCK_HARMONY_JWT = "mock-harmony-jwt";
+    private final String HARMONY_JWT = "harmonyJWT";
+    private final String HARMONY_COURSES_API_URL = "harmonyCoursesApiUrl";
     private final String SAMPLE_ROOT_OUTCOME_GUID = "root";
     private final String SAMPLE_PI_GUID = "sample-pi-guid";
+    private final String SAMPLE_ID_TOKEN = "sample-id-token";
 
     @InjectMocks
     private HarmonyService harmonyService;
@@ -49,50 +54,50 @@ public class HarmonyServiceTest {
 
     @Test
     public void testNullCredentials() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", null);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", null);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, null);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, null);
         assertNull(harmonyService.fetchHarmonyCourses(1));
     }
 
     @Test
     public void testEmptyCredentials() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "");
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, "");
         assertNull(harmonyService.fetchHarmonyCourses(1));
     }
 
     @Test
     public void testNullUrl() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", null);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, null);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
         assertNull(harmonyService.fetchHarmonyCourses(1));
     }
 
     @Test
     public void testNullToken() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "nonnull");
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", null);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, null);
         assertNull(harmonyService.fetchHarmonyCourses(1));
     }
 
     @Test
     public void testEmptyUrl() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "");
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
         assertNull(harmonyService.fetchHarmonyCourses(1));
     }
 
     @Test
     public void testEmptyToken() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "nonnull");
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, "");
         assertNull(harmonyService.fetchHarmonyCourses(1));
     }
 
     @Test
     public void testNotValidURL() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "notvalid");
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "notvalid");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
         when(restTemplate.exchange(eq("notvalid"), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
         assertNull(harmonyService.fetchHarmonyCourses(1));
@@ -100,8 +105,8 @@ public class HarmonyServiceTest {
 
     @Test
     public void testForbiddenRequest() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
 
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.FORBIDDEN);
         when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
@@ -111,8 +116,8 @@ public class HarmonyServiceTest {
 
     @Test
     public void testBadRequest() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
 
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
         when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
@@ -122,8 +127,8 @@ public class HarmonyServiceTest {
 
     @Test
     public void testWrongResponse() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
 
         when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenThrow(new HttpMessageNotReadableException("JSON not able to be parsed", new MockHttpInputMessage("[{\"not\": \"root\",\"valid\": \"Root\",\"schema\": null}]".getBytes(StandardCharsets.UTF_8))));
         assertNull(harmonyService.fetchHarmonyCourses(1));
@@ -131,8 +136,8 @@ public class HarmonyServiceTest {
 
     @Test
     public void testGoodResponse() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
 
         HarmonyCourse harmonyCourse = new HarmonyCourse();
         harmonyCourse.setRoot_outcome_guid("root");
@@ -167,8 +172,8 @@ public class HarmonyServiceTest {
 
     @Test
     public void testRequestedPage() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
 
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(new HarmonyPageResponse(), HttpStatus.OK);
         // Ensure that the service requests the right page
@@ -190,118 +195,134 @@ public class HarmonyServiceTest {
 
     @Test
     public void testNullCredentialsForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", null);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", null);
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID));
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, null);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, null);
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID, SAMPLE_ID_TOKEN));
     }
 
     @Test
     public void testEmptyCredentialsForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "");
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "");
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID));
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, "");
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID, SAMPLE_ID_TOKEN));
     }
 
     @Test
     public void testNullUrlForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", null);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID));
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, null);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID, SAMPLE_ID_TOKEN));
     }
 
     @Test
     public void testNullTokenForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "nonnull");
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", null);
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID));
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_HARMONY_JWT);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, null);
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID, SAMPLE_ID_TOKEN));
     }
 
     @Test
     public void testEmptyUrlForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "");
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID));
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID, SAMPLE_ID_TOKEN));
     }
 
     @Test
     public void testEmptyTokenForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "nonnull");
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "");
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID));
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, "");
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID, SAMPLE_ID_TOKEN));
     }
 
     @Test
     public void testEmptyRootOutcomeGuidForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
-        assertNull(harmonyService.fetchDeepLinkingContentItems("", SAMPLE_PI_GUID));
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
+        assertNull(harmonyService.fetchDeepLinkingContentItems("", SAMPLE_PI_GUID, SAMPLE_ID_TOKEN));
     }
 
     @Test
     public void testNullRootOutcomeGuidForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
-        assertNull(harmonyService.fetchDeepLinkingContentItems(null, SAMPLE_PI_GUID));
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
+        assertNull(harmonyService.fetchDeepLinkingContentItems(null, SAMPLE_PI_GUID, SAMPLE_ID_TOKEN));
     }
 
     @Test
     public void testEmptyPiGuidForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, ""));
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, "", SAMPLE_ID_TOKEN));
     }
 
     @Test
     public void testNullPiGuidForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, null));
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, null, SAMPLE_ID_TOKEN));
     }
 
     @Test
     public void testNotValidURLForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", "notvalid");
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "notvalid");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
         when(restTemplate.exchange(eq("notvalid"), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID));
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID, SAMPLE_ID_TOKEN));
+    }
+
+    @Test
+    public void testBlankIdTokenForFetchDeepLinkingContentItems() {
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
+
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID, ""));
+    }
+
+    @Test
+    public void testNullIdTokenForFetchDeepLinkingContentItems() {
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
+
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID, null));
     }
 
     @Test
     public void testForbiddenRequestForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
 
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.FORBIDDEN);
         when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
 
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID));
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID, SAMPLE_ID_TOKEN));
     }
 
     @Test
     public void testBadRequestForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
 
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
         when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
 
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID));
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID, SAMPLE_ID_TOKEN));
     }
 
     @Test
     public void testWrongResponseForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
 
         when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenThrow(new HttpMessageNotReadableException("JSON not able to be parsed", new MockHttpInputMessage("[{\"not\": \"root\",\"valid\": \"Root\",\"schema\": null}]".getBytes(StandardCharsets.UTF_8))));
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID));
+        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID, SAMPLE_ID_TOKEN));
     }
 
     @Test
     public void testGoodResponseForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, "harmonyCoursesApiUrl", MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, "harmonyJWT", "nonnull");
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
+        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
 
         HarmonyContentItemDTO deepLinkingContentItemDTO1 = new HarmonyContentItemDTO();
         deepLinkingContentItemDTO1.setTitle("Reading 1");
@@ -317,12 +338,16 @@ public class HarmonyServiceTest {
         HarmonyContentItemDTO[] deepLinkingContentItems = new HarmonyContentItemDTO[]{deepLinkingContentItemDTO1, deepLinkingContentItemDTO2};
 
         ResponseEntity<HarmonyContentItemDTO[]> responseEntity = new ResponseEntity<>(deepLinkingContentItems, HttpStatus.OK);
-        String deepLinkingUrl = MOCK_SERVER_URL + "/lti_deep_links?guid=" + SAMPLE_ROOT_OUTCOME_GUID + "&pi_guid=" + SAMPLE_PI_GUID;
-        when(restTemplate.exchange(eq(deepLinkingUrl), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyContentItemDTO[].class))).thenReturn(responseEntity);
+        String deepLinkingUrl = MOCK_SERVER_URL + "/lti_deep_links?guid=" + SAMPLE_ROOT_OUTCOME_GUID + "&pi_guid=" + SAMPLE_PI_GUID + "&course_paired=false";
+        ArgumentCaptor<HttpEntity<String>> httpEntityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+        when(restTemplate.exchange(eq(deepLinkingUrl), eq(HttpMethod.GET), httpEntityCaptor.capture(), eq(HarmonyContentItemDTO[].class))).thenReturn(responseEntity);
 
-        List<HarmonyContentItemDTO> deepLinkingContentItemsList = harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID);
+        List<HarmonyContentItemDTO> deepLinkingContentItemsList = harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_PI_GUID, SAMPLE_ID_TOKEN);
 
         assertNotNull(deepLinkingContentItemsList);
+        HttpEntity<String> httpEntity = httpEntityCaptor.getValue();
+        assertEquals("Bearer " + MOCK_HARMONY_JWT, Objects.requireNonNull(httpEntity.getHeaders().get("Authorization")).get(0));
+        assertEquals("{\"id_token\":\"sample-id-token\"}", httpEntity.getBody());
         assertEquals(2, deepLinkingContentItemsList.size());
         assertTrue(deepLinkingContentItemsList.contains(deepLinkingContentItemDTO1));
         assertTrue(deepLinkingContentItemsList.contains(deepLinkingContentItemDTO2));


### PR DESCRIPTION
## Description
 - Included the id_token in the body of the request to harmony for deep links.
 - Included course_paired=false as a default request parameter of the request to harmony for deep links.
 - Reduced number of String literals in unit tests in code cleanup effort
 - Changed logging level from warn to error when parameters are missing for the deep link request

### Motivation and Context
Adding the id_token to the body of the request will make it easier for Harmony to validate the customer account from which the request for deep links originated. Adding the course_paired=false parameter will also ensure that no breaking changes are introduced as the subsequent launch code is still under development. 

### Fixes
[DL3-51](https://lumenlearning.atlassian.net/browse/DL3-51)

## How Has This Been Tested?
Smoke test:
1. Ensure that you have an LMS course and that the tool is already registered and accessible in that course.
2. Click through the LMS to enter the Deep Linking flow.
3. Select a course from the course catalog page.
4. Click the Add Course button.
5. Wait for the LMS to relaod.
6. Ensure that the links were still added to the LMS.

## Screenshots
N/A
---
## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
N/A

## New ENV variables
N/A

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
