### PR TITLE
DL3-18 Fix unit test mocking strategy so that old id_tokens are not reused

### DIFF
--- a/src/main/java/net/unicon/lti/controller/lti/LtiContextController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LtiContextController.java
@@ -44,8 +44,6 @@ public class LtiContextController {
     @Autowired
     HarmonyService harmonyService;
 
-    LTI3Request lti3Request;
-
     @PutMapping
     ResponseEntity<Object> pairBookToLMSContext(@RequestBody Map<String, String> pairBookBody) {
         try {
@@ -56,7 +54,7 @@ public class LtiContextController {
                 return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid request");
             }
             // validate id_token, including proving existence of single platformDeployment, generate id_token object
-            lti3Request = lti3Request == null ? new LTI3Request(ltiDataService, true, null, idToken) : lti3Request;
+            LTI3Request lti3Request = LTI3Request.makeLTI3Request(ltiDataService, true, null, idToken);
 
             // Retrieve LMS config from db to be used to find the right context
             List<PlatformDeployment> platformDeploymentList = platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(lti3Request.getIss(), lti3Request.getAud(), lti3Request.getLtiDeploymentId());

--- a/src/main/java/net/unicon/lti/utils/lti/LTI3Request.java
+++ b/src/main/java/net/unicon/lti/utils/lti/LTI3Request.java
@@ -851,4 +851,8 @@ public class LTI3Request {
         }
         return roleNum;
     }
+
+    public static LTI3Request makeLTI3Request(LTIDataService ltiDataService, boolean update, String linkId, String jwt) throws DataServiceException {
+        return new LTI3Request(ltiDataService, update, linkId, jwt);
+    }
 }

--- a/src/test/java/net/unicon/lti/controller/lti/LtiContextControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/LtiContextControllerTest.java
@@ -62,17 +62,21 @@ public class LtiContextControllerTest {
     @Mock
     LTI3Request lti3Request;
 
+    private MockedStatic<LTI3Request> lti3RequestMockedStatic;
+
     private MockedStatic<DeepLinkUtils> deepLinkUtilsMockedStatic;
 
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         deepLinkUtilsMockedStatic = Mockito.mockStatic(DeepLinkUtils.class);
+        lti3RequestMockedStatic = Mockito.mockStatic(LTI3Request.class);
     }
 
     @AfterEach
     public void close() {
         deepLinkUtilsMockedStatic.close();
+        lti3RequestMockedStatic.close();
     }
 
     @Test
@@ -98,6 +102,7 @@ public class LtiContextControllerTest {
     @Test
     public void testPairBookWithoutLtiContext() {
         Map<String, String> pairBookBody = Map.of(ROOT_OUTCOME_GUID, SAMPLE_ROOT_OUTCOME_GUID, ID_TOKEN, SAMPLE_DL_ID_TOKEN);
+        lti3RequestMockedStatic.when(() -> LTI3Request.makeLTI3Request(eq(ltiDataService), eq(true), eq(null), eq(SAMPLE_DL_ID_TOKEN))).thenReturn(lti3Request);
         when(lti3Request.getLtiContextId()).thenReturn(SAMPLE_CONTEXT_ID);
         when(lti3Request.getIss()).thenReturn(SAMPLE_ISSUER);
         when(lti3Request.getAud()).thenReturn(SAMPLE_CLIENT_ID);
@@ -115,6 +120,7 @@ public class LtiContextControllerTest {
     @Test
     public void testPairBookWithoutDeepLinkingContentItemsFromHarmony() {
         Map<String, String> pairBookBody = Map.of(ROOT_OUTCOME_GUID, SAMPLE_ROOT_OUTCOME_GUID, ID_TOKEN, SAMPLE_DL_ID_TOKEN);
+        lti3RequestMockedStatic.when(() -> LTI3Request.makeLTI3Request(eq(ltiDataService), eq(true), eq(null), eq(SAMPLE_DL_ID_TOKEN))).thenReturn(lti3Request);
         when(lti3Request.getLtiContextId()).thenReturn(SAMPLE_CONTEXT_ID);
         when(lti3Request.getIss()).thenReturn(SAMPLE_ISSUER);
         when(lti3Request.getAud()).thenReturn(SAMPLE_CLIENT_ID);
@@ -134,6 +140,7 @@ public class LtiContextControllerTest {
     @Test
     public void testPairBookWithNullDeepLinkingContentItemsFromHarmony() {
         Map<String, String> pairBookBody = Map.of(ROOT_OUTCOME_GUID, SAMPLE_ROOT_OUTCOME_GUID, ID_TOKEN, SAMPLE_DL_ID_TOKEN);
+        lti3RequestMockedStatic.when(() -> LTI3Request.makeLTI3Request(eq(ltiDataService), eq(true), eq(null), eq(SAMPLE_DL_ID_TOKEN))).thenReturn(lti3Request);
         when(lti3Request.getLtiContextId()).thenReturn(SAMPLE_CONTEXT_ID);
         when(lti3Request.getIss()).thenReturn(SAMPLE_ISSUER);
         when(lti3Request.getAud()).thenReturn(SAMPLE_CLIENT_ID);
@@ -153,6 +160,7 @@ public class LtiContextControllerTest {
     @Test
     public void testPairBookDeepLinkingResponseGenerationThrowsException() {
         Map<String, String> pairBookBody = Map.of(ROOT_OUTCOME_GUID, SAMPLE_ROOT_OUTCOME_GUID, ID_TOKEN, SAMPLE_DL_ID_TOKEN);
+        lti3RequestMockedStatic.when(() -> LTI3Request.makeLTI3Request(eq(ltiDataService), eq(true), eq(null), eq(SAMPLE_DL_ID_TOKEN))).thenReturn(lti3Request);
         when(lti3Request.getLtiContextId()).thenReturn(SAMPLE_CONTEXT_ID);
         when(lti3Request.getIss()).thenReturn(SAMPLE_ISSUER);
         when(lti3Request.getAud()).thenReturn(SAMPLE_CLIENT_ID);
@@ -174,6 +182,7 @@ public class LtiContextControllerTest {
     @Test
     public void testPairBook() {
         Map<String, String> pairBookBody = Map.of(ROOT_OUTCOME_GUID, SAMPLE_ROOT_OUTCOME_GUID, ID_TOKEN, SAMPLE_DL_ID_TOKEN);
+        lti3RequestMockedStatic.when(() -> LTI3Request.makeLTI3Request(eq(ltiDataService), eq(true), eq(null), eq(SAMPLE_DL_ID_TOKEN))).thenReturn(lti3Request);
         when(lti3Request.getLtiContextId()).thenReturn(SAMPLE_CONTEXT_ID);
         when(lti3Request.getIss()).thenReturn(SAMPLE_ISSUER);
         when(lti3Request.getAud()).thenReturn(SAMPLE_CLIENT_ID);


### PR DESCRIPTION
## Description
I have now switched from using a global variable for the id_token to creating a method for the LTI3Request class that calls the constructor, allowing the unit tests to still function while not reusing old id_tokens on subsequent deep linking launches.

### Motivation and Context
Mockito does not support mocking constructors. Initially, to avoid the need to mock the constructor for the id_token variable (lti3Request), I created a global variable for it. Unfortunately, this meant that this variable would stay in memory without getting overwritten for subsequent requests, leading to subsequent deep linking requests failing. I have now switched from using a global variable for the id_token to creating a method for the LTI3Request class that calls the constructor. Since Mockito supports mocking methods, the unit tests still work the same.

### Fixes
[DL3-18](https://lumenlearning.atlassian.net/browse/DL3-18)

## How Has This Been Tested?
1. As a prerequisite, the tool needs to be set up for Deep Linking in the LMS along with a course that has access to the tool.
2. Initiate the Deep Linking flow for a module in the course.
3. Select a course from the catalog that has sub-topics.
4. Click the Add Course button.
5. Wait 1-2 minutes for the links to get inserted into the course.
6. Reinitiate the Deep Linking flow.
7. Select a course from the catalog that has sub-topics.
8. Click the Add Course button.
9. Wait 1-2 minutes for the links to get inserted into the course.

## Screenshots
N/A
---

## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
N/A

## New ENV variables
N/A

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
