### PR TITLE
DL3-39 Display error message if deeplinks aren't successfully added

### DIFF
--- a/src/main/frontend/src/App.css
+++ b/src/main/frontend/src/App.css
@@ -140,10 +140,19 @@ li:not(:last-child) {
   background-color: #eef0fd !important;
   border: none !important;
   border-radius: 0.5rem !important;
+  color: #202325 !important;
 }
 
 .alert-danger {
   background-color: #ffdede !important;
   border: none !important;
   border-radius: 0.5rem !important;
+  color: #202325 !important;
+}
+
+.floating-alert {
+  position: fixed;
+  width: 100%;
+  padding: 1rem;
+  padding-right: 2.5rem;
 }

--- a/src/main/frontend/src/features/CoursePreview.js
+++ b/src/main/frontend/src/features/CoursePreview.js
@@ -1,3 +1,5 @@
+// React imports
+import React, { useState } from 'react';
 // Redux imports
 import { useDispatch } from 'react-redux';
 // Store imports
@@ -6,13 +8,19 @@ import { parseCourseCoverImage } from '../util/Utils.js';
 
 import Button from 'react-bootstrap/Button';
 import Col from 'react-bootstrap/Col';
+import Collapse  from 'react-bootstrap/Collapse';
 import CourseTOC from './CourseTOC';
+import ErrorAlert from './alerts/ErrorAlert';
 import Header from './Header';
 import Image from 'react-bootstrap/Image';
 import InfoAlert from './alerts/InfoAlert';
 import Row from 'react-bootstrap/Row';
 
 function CoursePreview(props) {
+
+  // In case there's an error adding the links, display an error message.
+  const [errorAddingLinks, setErrorAddingLinks] = useState(false);
+  const errorMessage = 'Oops, the Lumen content was not successfully added. Please try again or contact Lumen Support.';
 
   const dispatch = useDispatch();
 
@@ -56,11 +64,18 @@ function CoursePreview(props) {
         formField.value = response.JWT;
         form.appendChild(formField);
         form.submit();
+      }).catch(reason => {
+        setErrorAddingLinks(true);
       });
   }
 
   return (
     <>
+      <Collapse in={errorAddingLinks}>
+        <div className="floating-alert">
+          <ErrorAlert dismissible="dismissible" onClose={() => setErrorAddingLinks(false)} message={errorMessage}/>
+        </div>
+      </Collapse>
       <div className="header">
         <Row>
           <Col>

--- a/src/main/frontend/src/features/alerts/ErrorAlert.js
+++ b/src/main/frontend/src/features/alerts/ErrorAlert.js
@@ -2,7 +2,11 @@
 import Alert from 'react-bootstrap/Alert';
 
 function ErrorAlert(props) {
-  return <Alert variant="danger"><i className="fa fa-exclamation-circle error-icon" aria-hidden="true"></i> {props.message} </Alert>;
+  return <Alert variant="danger"
+           onClose={props.onClose}
+           dismissible={props.dismissible}>
+             <i className="fa fa-exclamation-circle error-icon" aria-hidden="true"></i> {props.message}
+         </Alert>;
 }
 
 export default ErrorAlert;


### PR DESCRIPTION
When a user clicks on 'Add Course' and there's an error with the request, displays a message informing the user about the issue.

## Description
When a user clicks on 'Add Course' and there's an error with the request, displays a message informing the user about the issue.

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/DL3-39)

## How Has This Been Tested?
Tested locally without the backend, it always shows an error.

## Screenshots
![DL3-39_2](https://user-images.githubusercontent.com/8653754/183644696-89063f3d-c4df-4c91-9416-664dbbf9d4b3.jpg)
![DL3-39](https://user-images.githubusercontent.com/8653754/183673942-9f0f7dcd-2753-4025-bfe4-fc1bd2677198.gif)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the AC for this feature and my changes meet all requirements
- [X] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have requested a review from at least one other dev
