### PR TITLE
DL3-54 Accessibility Issue on Course Select UI - Can not select a Cou…

### DIFF
--- a/src/main/frontend/src/features/CourseCard.js
+++ b/src/main/frontend/src/features/CourseCard.js
@@ -11,13 +11,23 @@ function CourseCard (props) {
   // Some courses may not have a valid cover image, use a default instead
   const courseCoverUrl = parseCourseCoverImage(props.course.cover_img_url);
 
+  // If the pressed key is the enter we have to select the course.
+  const checkPressedKey = (e) => {
+    if (e.key === 'Enter') {
+      dispatch(changeSelectedCourse(props.course));
+    }
+  }
+
   return (
-    <Card onClick={(e) => dispatch(changeSelectedCourse(props.course))} className="course-card">
-      <Card.Img variant="top" src={courseCoverUrl} className="course-card-image " title={props.course.book_title}/>
-      <Card.Body>
-        <Card.Title className="course-card-title">{props.course.book_title ? props.course.book_title : 'This course does not have a title.'}</Card.Title>
-        <Card.Subtitle className="course-card-subtitle">Released: {props.course.release_date ? formatDate(props.course.release_date) : 'No release date has been provided.'}</Card.Subtitle>
-      </Card.Body>
+    <Card className="course-card"
+      tabindex="0"
+      onKeyPress={(e) => checkPressedKey(e)}
+      onClick={(e) => dispatch(changeSelectedCourse(props.course))} >
+        <Card.Img variant="top" src={courseCoverUrl} className="course-card-image" title={props.course.book_title}/>
+        <Card.Body>
+          <Card.Title className="course-card-title">{props.course.book_title ? props.course.book_title : 'This course does not have a title.'}</Card.Title>
+          <Card.Subtitle className="course-card-subtitle">Released: {props.course.release_date ? formatDate(props.course.release_date) : 'No release date has been provided.'}</Card.Subtitle>
+        </Card.Body>
     </Card>
   );
 


### PR DESCRIPTION
…rse using only keyboard

## Description
Fixes an accessibility issue making the course cards navigable and selectable using the keyboard.

### Motivation and Context
Fix an accessibility issue.

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/DL3-54)

## How Has This Been Tested?
This has been tested locally and using D2L, able to navigate to the course using only the keyboard.

## Screenshots
![DL3-54](https://user-images.githubusercontent.com/8653754/183686424-2a3fb234-2c5a-416d-b540-5fc186e458b6.gif)

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the AC for this feature and my changes meet all requirements
- [X] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have requested a review from at least one other dev
