### PR TITLE
DL3-62 - Fix RestTemplate with GET body

### DIFF
--- a/src/main/java/net/unicon/lti/service/harmony/HarmonyService.java
+++ b/src/main/java/net/unicon/lti/service/harmony/HarmonyService.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import net.unicon.lti.model.harmony.HarmonyContentItemDTO;
 import net.unicon.lti.model.harmony.HarmonyPageResponse;
+import net.unicon.lti.utils.RestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,8 +24,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.BufferingClientHttpRequestFactory;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -48,8 +47,6 @@ public class HarmonyService {
     @Value("${harmony.courses.jwt}")
     private String harmonyJWT;
 
-    RestTemplate restTemplate;
-
     public HarmonyPageResponse fetchHarmonyCourses(int page) {
 
         if (StringUtils.isAnyBlank(harmonyCoursesApiUrl, harmonyJWT)) {
@@ -59,7 +56,7 @@ public class HarmonyService {
 
         try {
 
-            restTemplate = restTemplate == null ? new RestTemplate(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory())) : restTemplate;
+            RestTemplate restTemplate = RestUtils.createRestTemplate();
 
             // Build the URL
             String requestUrl = harmonyCoursesApiUrl;
@@ -110,7 +107,7 @@ public class HarmonyService {
         }
 
         try {
-            restTemplate = restTemplate == null ? new RestTemplate(new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory())) : restTemplate;
+            RestTemplate restTemplate = RestUtils.createRestTemplate();
 
             // Build the URL
             String requestUrl = harmonyCoursesApiUrl;

--- a/src/main/java/net/unicon/lti/utils/RestUtils.java
+++ b/src/main/java/net/unicon/lti/utils/RestUtils.java
@@ -1,0 +1,38 @@
+package net.unicon.lti.utils;
+
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+
+public class RestUtils {
+
+    public static RestTemplate createRestTemplate() {
+        return new RestTemplate(new CustomHttpComponentsClientHttpRequestFactory());
+    }
+
+    private static final class CustomHttpComponentsClientHttpRequestFactory extends HttpComponentsClientHttpRequestFactory {
+        @Override
+        protected HttpUriRequest createHttpUriRequest(HttpMethod httpMethod, URI uri) {
+
+            if (HttpMethod.GET.equals(httpMethod)) {
+                return new HttpEntityEnclosingGetRequestBase(uri);
+            }
+            return super.createHttpUriRequest(httpMethod, uri);
+        }
+    }
+
+    private static final class HttpEntityEnclosingGetRequestBase extends HttpEntityEnclosingRequestBase {
+        public HttpEntityEnclosingGetRequestBase(final URI uri) {
+            super.setURI(uri);
+        }
+
+        @Override
+        public String getMethod() {
+            return HttpMethod.GET.name();
+        }
+    }
+}

--- a/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
@@ -1,15 +1,19 @@
 package net.unicon.lti.service.harmony;
 
+import net.unicon.lti.model.harmony.HarmonyContentItemDTO;
 import net.unicon.lti.model.harmony.HarmonyCourse;
 import net.unicon.lti.model.harmony.HarmonyMetadata;
 import net.unicon.lti.model.harmony.HarmonyMetadataLinks;
 import net.unicon.lti.model.harmony.HarmonyPageResponse;
-import net.unicon.lti.model.harmony.HarmonyContentItemDTO;
+import net.unicon.lti.utils.RestUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -47,9 +51,18 @@ public class HarmonyServiceTest {
     @Mock
     private RestTemplate restTemplate;
 
+    private MockedStatic<RestUtils> restUtilsMockedStatic;
+
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
+        restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class);
+        restUtilsMockedStatic.when(RestUtils::createRestTemplate).thenReturn(restTemplate);
+    }
+
+    @AfterEach
+    public void close() {
+        restUtilsMockedStatic.close();
     }
 
     @Test


### PR DESCRIPTION
## Description
Added a workaround so that RestTemplate would be compatible with GET requests that include a body

### Motivation and Context
This solves the problem of receiving a 422 error when trying to fetch Deep Links from Harmony without the id_token in the body.

### Fixes
[DL3-62](https://lumenlearning.atlassian.net/browse/DL3-62)

## How Has This Been Tested?
1. Ensure that the LMS course is configured to have access to the tool with Deep Linking.
2. Initiate the deep linking flow for a module in the LMS course.
3. Select the Lifespan Development course from the catalog since this one has links in it.
4. Click the "Add Course" button.
5. Wait 1-2 minutes for the links to be added to the LMS.

## Screenshots
N/A

---
## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
N/A

## New ENV variables
N/A

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
