### PR TITLE
DL3-45 Display an error when the configured root_outcome_guid does not match any Harmony course

### DIFF
--- a/src/main/frontend/src/App.css
+++ b/src/main/frontend/src/App.css
@@ -59,6 +59,8 @@
 
 .course-card-image {
   border-radius: 1rem 1rem 0 0 !important;
+  height: 120px;
+  object-fit: cover;
 }
 
 .course-card-title {

--- a/src/main/frontend/src/features/CoursePicker.js
+++ b/src/main/frontend/src/features/CoursePicker.js
@@ -1,6 +1,6 @@
 // Redux imports
 import { useSelector } from 'react-redux';
-import { selectErrorFetchingCourses } from '../app/appSlice';
+import { selectErrorAssociatingCourse, selectErrorFetchingCourses } from '../app/appSlice';
 
 // Components import
 import Col from 'react-bootstrap/Col';
@@ -15,11 +15,19 @@ function CoursePicker (props) {
 
   // useSelector gets the value present in the store, this value may change at a component level.
   const isErrorFetchingCourses = useSelector(selectErrorFetchingCourses);
+  const isErrorAssociatingCourse = useSelector(selectErrorAssociatingCourse);
 
   // Display an error message when the courses cannot be fetched from Harmony.
   if (isErrorFetchingCourses) {
     return <div className="header">
              <Row><ErrorAlert message="Oops, we couldn't load the Lumen content. Please try again." /></Row>
+           </div>;
+  }
+
+  // Display an error message when the LMS course has been paired with a non existing Lumen course.
+  if (isErrorAssociatingCourse) {
+    return <div className="header">
+             <Row><ErrorAlert message="Oops, something went wrong. We could not add the correct Lumen content links for your course. Please contact Lumen Support." /></Row>
            </div>;
   }
 

--- a/src/main/frontend/src/index.js
+++ b/src/main/frontend/src/index.js
@@ -32,6 +32,7 @@ const initialState = {
   selectedCourse: null,
   loading: true,
   errorFetchingCourses: false,
+  errorAssociatingCourse: false,
   selectedModules: [],
   // These variables are related to the LTI Launch data.
   deploymentId: ltiLaunchData.deploymentId,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including your Jira ticket ID. -->

## Description
Shows an error when the Middleware provides a configured root_outcome_guid that does not match with any Harmony current course.

Displays the selected course when the backend sends to the frontend a previous root_outcome_guid.

### Motivation and Context
The user can pair an LMS course with a Harmony course, then the Middleware will send to the frontend the root_outcome_guid , this value can be invalid if the course does not exist in the Harmony endpoint anymore.

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/DL3-45)

## How Has This Been Tested?
This has been tested locally simulating all the possible combinations. 

## Screenshots

When the previously selected course exists displays it.
![DL3-45](https://user-images.githubusercontent.com/8653754/187153501-72b53440-0c83-42c9-bb97-1d1f16dcb65c.gif)

When the previously selected course does not exist displays an error:
![DL3-45-2](https://user-images.githubusercontent.com/8653754/187153567-51a36a58-240b-491d-9f21-25a65dc30750.gif)


---
<!-- The following section calls out any changes that will impact the deploy of this PR and/or need to be shared with the team post-deploy. It is not meant to be all-inclusive; if there are additional things to note here, make a heading and do so :) -->

## Database changes
<!-- Describe any database changes here. -->

## ⚠️ Deployment instructions ⚠️
<!-- Make note of any unique-to-this-PR deployment instructions here. -->

## New ENV variables
<!-- Document any new ENV variables added as part of this work -->

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the AC for this feature and my changes meet all requirements
- [X] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have requested a review from at least one other dev.
