### PR TITLE
DL3-64 switch from get to post when fetching deep links

### DIFF
--- a/src/main/java/net/unicon/lti/service/harmony/HarmonyService.java
+++ b/src/main/java/net/unicon/lti/service/harmony/HarmonyService.java
@@ -76,7 +76,7 @@ public class HarmonyService {
 
             HttpHeaders headers = new HttpHeaders();
             headers.setBearerAuth(harmonyJWT);
-            HttpEntity<String> entity = new HttpEntity<>("parameters", headers);
+            HttpEntity<String> entity = new HttpEntity<>(headers);
             ResponseEntity<HarmonyPageResponse> response = restTemplate.exchange(requestUrl, HttpMethod.GET, entity, HarmonyPageResponse.class);
             if (response.getStatusCode().is2xxSuccessful()) {
                 return response.getBody();

--- a/src/main/java/net/unicon/lti/service/harmony/HarmonyService.java
+++ b/src/main/java/net/unicon/lti/service/harmony/HarmonyService.java
@@ -122,7 +122,7 @@ public class HarmonyService {
             HarmonyFetchDeepLinksBody body = new HarmonyFetchDeepLinksBody(null, idToken, moduleIds);
             HttpEntity<HarmonyFetchDeepLinksBody> entity = new HttpEntity<>(body, headers);
 
-            ResponseEntity<HarmonyContentItemDTO[]> response = restTemplate.exchange(requestUrl, HttpMethod.GET, entity, HarmonyContentItemDTO[].class);
+            ResponseEntity<HarmonyContentItemDTO[]> response = restTemplate.exchange(requestUrl, HttpMethod.POST, entity, HarmonyContentItemDTO[].class);
             if (response.getStatusCode().is2xxSuccessful()) {
                 return Arrays.asList(Objects.requireNonNull(response.getBody()));
             } else {

--- a/src/main/resources/application-aws.properties
+++ b/src/main/resources/application-aws.properties
@@ -28,7 +28,7 @@ spring.thymeleaf.mode=HTML5
 ## Logging settings
 #logging.level.org.apache.http=DEBUG
 #logging.level.org.springframework.web.client=DEBUG
-#logging.level.net.unicon=DEBUG
+logging.level.net.unicon=DEBUG
 #logging.level.org.springframework.web=DEBUG
 #logging.level.org.springframework.security=DEBUG
 #logging.level.org.hibernate=ERROR

--- a/src/main/resources/application-aws.properties
+++ b/src/main/resources/application-aws.properties
@@ -28,7 +28,7 @@ spring.thymeleaf.mode=HTML5
 ## Logging settings
 #logging.level.org.apache.http=DEBUG
 #logging.level.org.springframework.web.client=DEBUG
-logging.level.net.unicon=DEBUG
+#logging.level.net.unicon=DEBUG
 #logging.level.org.springframework.web=DEBUG
 #logging.level.org.springframework.security=DEBUG
 #logging.level.org.hibernate=ERROR

--- a/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
@@ -266,7 +266,7 @@ public class HarmonyServiceTest {
     @Test
     public void testForbiddenRequestForFetchDeepLinkingContentItems() {
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.FORBIDDEN);
-        when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
+        when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
 
         assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_ID_TOKEN, false, null));
     }
@@ -274,14 +274,14 @@ public class HarmonyServiceTest {
     @Test
     public void testBadRequestForFetchDeepLinkingContentItems() {
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
-        when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
+        when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
 
         assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_ID_TOKEN, false, null));
     }
 
     @Test
     public void testWrongResponseForFetchDeepLinkingContentItems() {
-        when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenThrow(new HttpMessageNotReadableException("JSON not able to be parsed", new MockHttpInputMessage("[{\"not\": \"root\",\"valid\": \"Root\",\"schema\": null}]".getBytes(StandardCharsets.UTF_8))));
+        when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.POST), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenThrow(new HttpMessageNotReadableException("JSON not able to be parsed", new MockHttpInputMessage("[{\"not\": \"root\",\"valid\": \"Root\",\"schema\": null}]".getBytes(StandardCharsets.UTF_8))));
         assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_ID_TOKEN, false, null));
     }
 
@@ -304,7 +304,7 @@ public class HarmonyServiceTest {
         String deepLinkingUrl = MOCK_SERVER_URL + "/lti_deep_links?guid=" + SAMPLE_ROOT_OUTCOME_GUID + "&course_paired=false";
         HarmonyFetchDeepLinksBody body = new HarmonyFetchDeepLinksBody(null, SAMPLE_ID_TOKEN, null);
         ArgumentCaptor<HttpEntity<HarmonyFetchDeepLinksBody>> httpEntityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
-        when(restTemplate.exchange(eq(deepLinkingUrl), eq(HttpMethod.GET), httpEntityCaptor.capture(), eq(HarmonyContentItemDTO[].class))).thenReturn(responseEntity);
+        when(restTemplate.exchange(eq(deepLinkingUrl), eq(HttpMethod.POST), httpEntityCaptor.capture(), eq(HarmonyContentItemDTO[].class))).thenReturn(responseEntity);
 
         List<HarmonyContentItemDTO> deepLinkingContentItemsList = harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_ID_TOKEN, false, null);
 
@@ -340,11 +340,11 @@ public class HarmonyServiceTest {
         String deepLinkingUrl = MOCK_SERVER_URL + "/lti_deep_links?guid=" + SAMPLE_ROOT_OUTCOME_GUID + "&course_paired=true";
         HarmonyFetchDeepLinksBody body = new HarmonyFetchDeepLinksBody(null, SAMPLE_ID_TOKEN, List.of("module-id-1", "module-id-2", "module-id-3"));
         ArgumentCaptor<HttpEntity<HarmonyFetchDeepLinksBody>> httpEntityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
-        when(restTemplate.exchange(eq(deepLinkingUrl), eq(HttpMethod.GET), any(), eq(HarmonyContentItemDTO[].class))).thenReturn(responseEntity);
+        when(restTemplate.exchange(eq(deepLinkingUrl), eq(HttpMethod.POST), any(), eq(HarmonyContentItemDTO[].class))).thenReturn(responseEntity);
 
         List<HarmonyContentItemDTO> deepLinkingContentItemsList = harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_ID_TOKEN, true, List.of("module-id-1", "module-id-2", "module-id-3"));
 
-        verify(restTemplate).exchange(eq(deepLinkingUrl), eq(HttpMethod.GET), httpEntityCaptor.capture(), eq(HarmonyContentItemDTO[].class));
+        verify(restTemplate).exchange(eq(deepLinkingUrl), eq(HttpMethod.POST), httpEntityCaptor.capture(), eq(HarmonyContentItemDTO[].class));
         assertNotNull(deepLinkingContentItemsList);
         HttpEntity<HarmonyFetchDeepLinksBody> httpEntity = httpEntityCaptor.getValue();
         assertEquals("Bearer " + MOCK_HARMONY_JWT, Objects.requireNonNull(httpEntity.getHeaders().get("Authorization")).get(0));


### PR DESCRIPTION
## Description
Switched from using a GET request to using a POST request when fetching Deep Links from Valkyrie.
Note: A GET request is still used when fetching the course catalog from Valkyrie.

### Motivation and Context
This change is required because AWS does not always allow GET requests with a body, so we are preemptively switching these requests to be POST requests instead.

### Fixes
[DL3-64](https://lumenlearning.atlassian.net/browse/DL3-64)

## How Has This Been Tested?
Smoke testing to confirm that none of the current ipswich functionality has been removed:
1. Create a new course in the LMS and ensure that it has permission to use the registered tool for Deep Linking.
2. Start the deep linking flow within the course.
3. Select a course from the menu that has data (e.g. Lifespan Development).
4. Keep the Select All checked by default and click Add Course.
5. Click on one of the Study Plan links that were added to the module in order to sync the lineitems permitting the returning user flow to work.
6. If desired create a new module to be able to differentiate the results from the previous tests and future testing.
7. In the new module, open the deep linking menu and return to the course preview for the selected course.
8. All of the checkboxes should be unchecked by default.
9. Select just one checkbox.
10. Click the Add Content button.
11. Note that only links associated with the selected module were added (and also what appears to be student resources links, this might be a bug in DL3-49).

## Screenshots
N/A
---

## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
N/A

## New ENV variables
N/A

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
