### PR TITLE
DL3-75 Add root_outcome_guid as request param when fetching course catalog

### DIFF
--- a/src/main/java/net/unicon/lti/controller/harmony/HarmonyRestController.java
+++ b/src/main/java/net/unicon/lti/controller/harmony/HarmonyRestController.java
@@ -42,14 +42,14 @@ public class HarmonyRestController {
     LTI3Request lti3Request;
 
     @RequestMapping(value = "/courses")
-    public ResponseEntity<HarmonyPageResponse> listHarmonyCourses(@RequestHeader(value="lti-id-token") String ltiIdToken, @RequestParam int page) {
+    public ResponseEntity<HarmonyPageResponse> listHarmonyCourses(@RequestHeader(value="lti-id-token") String ltiIdToken, @RequestParam(required = false) Integer page, @RequestParam(required = false, value = "root_outcome_guid") String rootOutcomeGuid) {
         //To keep this endpoint secured, we will validate the id_token
         try {
             // validates JWT signature, ensures existing platformDeployment, validates 1.3 format of JWT, validates nonce
             lti3Request = new LTI3Request(ltiDataService, true, null, ltiIdToken);
             log.debug("The id_token is valid, fetching courses....");
             // We convert the JSON response to a Java object, and send the JSON value again to the frontend.
-            return ResponseEntity.ok(harmonyService.fetchHarmonyCourses(page));
+            return ResponseEntity.ok(harmonyService.fetchHarmonyCourses(page, rootOutcomeGuid));
         } catch (Exception e) {
             log.debug(e.getMessage());
             log.debug("No permissions to fetch courses from Harmony");

--- a/src/main/java/net/unicon/lti/service/harmony/HarmonyService.java
+++ b/src/main/java/net/unicon/lti/service/harmony/HarmonyService.java
@@ -53,7 +53,7 @@ public class HarmonyService {
     @Value("${harmony.courses.jwt}")
     private String harmonyJWT;
 
-    public HarmonyPageResponse fetchHarmonyCourses(int page) {
+    public HarmonyPageResponse fetchHarmonyCourses(Integer page, String rootOutcomeGuid) {
 
         if (StringUtils.isAnyBlank(harmonyCoursesApiUrl, harmonyJWT)) {
             log.warn("The Harmony Courses API has not been configured, courses will not be fetched.");
@@ -65,15 +65,15 @@ public class HarmonyService {
             RestTemplate restTemplate = RestUtils.createRestTemplate();
 
             // Build the URL
-            String requestUrl = harmonyCoursesApiUrl;
-            // Only append the page parameter when it's needed.
-            if (page != 1) {
-                URIBuilder builder = new URIBuilder(harmonyCoursesApiUrl);
+            URIBuilder builder = new URIBuilder(harmonyCoursesApiUrl);
+            if (StringUtils.isNotEmpty(rootOutcomeGuid)) {
+                builder.addParameter("root_outcome_guid", rootOutcomeGuid);
+            } else if (page != null && page > 1) {
                 // Add the page parameter since this API is paginated.
                 builder.setParameter("page", String.valueOf(page));
-                requestUrl = builder.build().toString();
             }
 
+            String requestUrl = builder.build().toString();
             HttpHeaders headers = new HttpHeaders();
             headers.setBearerAuth(harmonyJWT);
             HttpEntity<String> entity = new HttpEntity<>(headers);

--- a/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
@@ -80,38 +80,38 @@ public class HarmonyServiceTest {
     public void testNullCredentials() {
         ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, null);
         ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, null);
-        assertNull(harmonyService.fetchHarmonyCourses(1));
+        assertNull(harmonyService.fetchHarmonyCourses(1, null));
     }
 
     @Test
     public void testEmptyCredentials() {
         ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "");
         ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, "");
-        assertNull(harmonyService.fetchHarmonyCourses(1));
+        assertNull(harmonyService.fetchHarmonyCourses(1, null));
     }
 
     @Test
     public void testNullUrl() {
         ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, null);
-        assertNull(harmonyService.fetchHarmonyCourses(1));
+        assertNull(harmonyService.fetchHarmonyCourses(1, null));
     }
 
     @Test
     public void testNullToken() {
         ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, null);
-        assertNull(harmonyService.fetchHarmonyCourses(1));
+        assertNull(harmonyService.fetchHarmonyCourses(1, null));
     }
 
     @Test
     public void testEmptyUrl() {
         ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "");
-        assertNull(harmonyService.fetchHarmonyCourses(1));
+        assertNull(harmonyService.fetchHarmonyCourses(1, null));
     }
 
     @Test
     public void testEmptyToken() {
         ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, "");
-        assertNull(harmonyService.fetchHarmonyCourses(1));
+        assertNull(harmonyService.fetchHarmonyCourses(1, null));
     }
 
     @Test
@@ -119,7 +119,7 @@ public class HarmonyServiceTest {
         ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "notvalid");
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
         when(restTemplate.exchange(eq("notvalid"), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
-        assertNull(harmonyService.fetchHarmonyCourses(1));
+        assertNull(harmonyService.fetchHarmonyCourses(1, null));
     }
 
     @Test
@@ -127,7 +127,7 @@ public class HarmonyServiceTest {
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.FORBIDDEN);
         when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
 
-        assertNull(harmonyService.fetchHarmonyCourses(1));
+        assertNull(harmonyService.fetchHarmonyCourses(1, null));
     }
 
     @Test
@@ -135,13 +135,13 @@ public class HarmonyServiceTest {
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(null, HttpStatus.BAD_REQUEST);
         when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
 
-        assertNull(harmonyService.fetchHarmonyCourses(1));
+        assertNull(harmonyService.fetchHarmonyCourses(1, null));
     }
 
     @Test
     public void testWrongResponse() {
         when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenThrow(new HttpMessageNotReadableException("JSON not able to be parsed", new MockHttpInputMessage("[{\"not\": \"root\",\"valid\": \"Root\",\"schema\": null}]".getBytes(StandardCharsets.UTF_8))));
-        assertNull(harmonyService.fetchHarmonyCourses(1));
+        assertNull(harmonyService.fetchHarmonyCourses(1, null));
     }
 
     @Test
@@ -164,7 +164,7 @@ public class HarmonyServiceTest {
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(harmonyPageResponse, HttpStatus.OK);
         when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
 
-        HarmonyPageResponse serviceResponse = harmonyService.fetchHarmonyCourses(1);
+        HarmonyPageResponse serviceResponse = harmonyService.fetchHarmonyCourses(1, null);
         assertNotNull(serviceResponse);
         assertEquals(serviceResponse.getRecords().size(), 1);
         assertEquals(serviceResponse.getRecords().get(0).getRoot_outcome_guid(), "root");
@@ -190,11 +190,44 @@ public class HarmonyServiceTest {
         when(restTemplate.exchange(eq(MOCK_SERVER_URL + "?page=4"), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
 
         // These pages do not include the response
-        assertNull(harmonyService.fetchHarmonyCourses(1));
-        assertNull(harmonyService.fetchHarmonyCourses(3));
+        assertNull(harmonyService.fetchHarmonyCourses(1, null));
+        assertNull(harmonyService.fetchHarmonyCourses(3, null));
         // These pages include the response
-        assertNotNull(harmonyService.fetchHarmonyCourses(2));
-        assertNotNull(harmonyService.fetchHarmonyCourses(4));
+        assertNotNull(harmonyService.fetchHarmonyCourses(2, null));
+        assertNotNull(harmonyService.fetchHarmonyCourses(4, null));
+    }
+
+    @Test
+    public void testFetchCourseByRootOutcomeGuid() {
+        HarmonyCourse harmonyCourse = new HarmonyCourse();
+        harmonyCourse.setRoot_outcome_guid("root");
+        harmonyCourse.setBook_title("Root");
+        HarmonyMetadata harmonyMetadata = new HarmonyMetadata();
+        harmonyMetadata.setPage("1");
+        harmonyMetadata.setPer_page("10");
+        harmonyMetadata.setPage_count(1);
+        harmonyMetadata.setTotal_count(1);
+        HarmonyMetadataLinks harmonyMetadataLinks = new HarmonyMetadataLinks();
+        harmonyMetadataLinks.setFirst("/service_api/course_catalog?page=1");
+        harmonyMetadataLinks.setLast("/service_api/course_catalog?page=1");
+        harmonyMetadata.setLinks(harmonyMetadataLinks);
+        HarmonyPageResponse harmonyPageResponse = new HarmonyPageResponse();
+        harmonyPageResponse.setRecords(List.of(harmonyCourse));
+        harmonyPageResponse.setMetadata(harmonyMetadata);
+        ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(harmonyPageResponse, HttpStatus.OK);
+        when(restTemplate.exchange(eq(MOCK_SERVER_URL + "?root_outcome_guid=root"), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
+
+        HarmonyPageResponse serviceResponse = harmonyService.fetchHarmonyCourses(1, "root");
+        assertNotNull(serviceResponse);
+        assertEquals(serviceResponse.getRecords().size(), 1);
+        assertEquals(serviceResponse.getRecords().get(0).getRoot_outcome_guid(), "root");
+        assertEquals(serviceResponse.getRecords().get(0).getBook_title(), "Root");
+        assertEquals(serviceResponse.getMetadata().getPage(), "1");
+        assertEquals(serviceResponse.getMetadata().getPage_count(), 1);
+        assertEquals(serviceResponse.getMetadata().getTotal_count(), 1);
+        assertEquals(serviceResponse.getMetadata().getPer_page(), "10");
+        assertNotNull(serviceResponse.getMetadata().getLinks().getFirst());
+        assertNotNull(serviceResponse.getMetadata().getLinks().getFirst());
     }
 
     @Test


### PR DESCRIPTION
## Description
I added the ability for the lti-middleware backend to accept the `root_outcome_guid` parameter for the Valkyrie /course_catalog endpoint to be able to return a single course based upon this value.

### Motivation and Context
This ensures maximal efficiency when skipping the course catalog page on the deep linking menu for subsequent launches when the LMS course has already been paired with a Lumen root_outcome_guid so that it can go straight to the course preview page for the paired course.

### Fixes
[DL3-75](https://lumenlearning.atlassian.net/browse/DL3-75)

## How Has This Been Tested?
Smoke testing to confirm that none of the current ipswich functionality has been removed:
1. Create a new course in the LMS and ensure that it has permission to use the registered tool for Deep Linking.
2. Start the deep linking flow within the course.
3. Select a course from the menu that has data (e.g. Lifespan Development).
4. Keep the Select All checked by default and click Add Course.
5. Click on one of the Study Plan links that were added to the module in order to sync the lineitems permitting the returning user flow to work.
6. If desired create a new module to be able to differentiate the results from the previous tests and future testing.
7. In the new module, open the deep linking menu and return to the course preview for the selected course.
8. All of the checkboxes should be unchecked by default.
9. Select just one checkbox.
10. Click the Add Content button.
11. Note that only links associated with the selected module were added (and also what appears to be student resources links, this might be a bug in DL3-49).

I also tried out this change with the code from DL3-45 and went through the steps above confirming that for step 7 the course catalog page was skipped and the course preview page for my paired course displayed instead.

## Screenshots
N/A
---

## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
N/A

## New ENV variables
N/A

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
