### PR TITLE
DL3-40 enable deep linking by default via dynamic registration

### DIFF
--- a/src/main/java/net/unicon/lti/service/lti/RegistrationService.java
+++ b/src/main/java/net/unicon/lti/service/lti/RegistrationService.java
@@ -1,9 +1,12 @@
 package net.unicon.lti.service.lti;
 
 import net.unicon.lti.exceptions.ConnectionException;
+import net.unicon.lti.model.lti.dto.PlatformRegistrationDTO;
 import net.unicon.lti.model.lti.dto.ToolRegistrationDTO;
 
 public interface RegistrationService {
     //Calling the membership service and getting a paginated result of users.
     String callDynamicRegistration(String token, ToolRegistrationDTO toolRegistrationDTO, String endpoint) throws ConnectionException;
+
+    ToolRegistrationDTO generateToolConfiguration(PlatformRegistrationDTO platformConfiguration);
 }

--- a/src/main/resources/application-aws.properties
+++ b/src/main/resources/application-aws.properties
@@ -55,6 +55,7 @@ oicd.publickey=-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBC
 application.url=NEEDS_OVERRIDE
 application.name=${LTI_MIDDLEWARE_NAME:Lumen Learning LTI 1.3}
 application.description=${LTI_MIDDLEWARE_DESCRIPTION:Lumen Learning LTI 1.3 integration}
+application.deep.linking.menu.label=${LTI_MIDDLEWARE_DL_LABEL:Lumen Content Selector}
 
 ##if the password is not set, a random one is generated and displayed on start in the log.
 terracotta.admin.user = admin

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -90,6 +90,7 @@ oicd.publickey=-----BEGIN PUBLIC KEY-----HERE THE RSA PUBLIC KEY-----END PUBLIC 
 application.url=https://example.unicon.net
 application.name=${LTI_MIDDLEWARE_NAME:Lumen Learning LTI 1.3}
 application.description=${LTI_MIDDLEWARE_DESCRIPTION:Lumen Learning LTI 1.3 integration}
+application.deep.linking.menu.label=${LTI_MIDDLEWARE_DL_LABEL:Lumen Content Selector}
 domain.url=https://goldilocks.lumenlearning.com
 
 ##if the password is not set, a random one is generated and displayed on start in the log.

--- a/src/test/java/net/unicon/lti/service/lti/test/RegistrationServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/lti/test/RegistrationServiceTest.java
@@ -2,25 +2,39 @@ package net.unicon.lti.service.lti.test;
 
 import net.unicon.lti.exceptions.ConnectionException;
 import net.unicon.lti.exceptions.helper.ExceptionMessageGenerator;
+import net.unicon.lti.model.lti.dto.PlatformRegistrationDTO;
+import net.unicon.lti.model.lti.dto.ToolConfigurationDTO;
+import net.unicon.lti.model.lti.dto.ToolMessagesSupportedDTO;
 import net.unicon.lti.model.lti.dto.ToolRegistrationDTO;
 import net.unicon.lti.service.lti.RegistrationService;
 import net.unicon.lti.service.lti.impl.RegistrationServiceImpl;
+import net.unicon.lti.utils.RestUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriTemplateHandler;
 
+import java.util.Arrays;
+import java.util.List;
+
+import static net.unicon.lti.utils.LtiStrings.LTI_OPTIONAL_CLAIMS;
+import static net.unicon.lti.utils.TextConstants.LTI3_SUFFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -30,8 +44,19 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class RegistrationServiceTest {
-
+    private static final String TEST_PLATFORM_ISSUER = "https://platform.com";
+    private static final List TEST_SCOPES = Arrays.asList("example-scope1", "example-scope2");
     private static final String TEST_REGISTRATION_ENDPOINT = "https://platform.com/register-tool";
+    private static final String LOCAL_URL = "localUrl";
+    private static final String SAMPLE_LOCAL_URL = "https://tool.com";
+    private static final String DOMAIN_URL = "domainUrl";
+    private static final String SAMPLE_DOMAIN_URL = "https://domain.tool.com";
+    private static final String CLIENT_NAME = "clientName";
+    private static final String SAMPLE_CLIENT_NAME = "Tool Name";
+    private static final String DESCRIPTION = "description";
+    private static final String SAMPLE_DESCRIPTION = "LTI 1.3 Tool Description";
+    private static final String DEEP_LINKING_MENU_LABEL = "deepLinkingMenuLabel";
+    private static final String SAMPLE_DEEP_LINKING_MENU_LABEL = "Tool Content Selector";
 
     @InjectMocks
     private RegistrationService registrationService = new RegistrationServiceImpl();
@@ -42,9 +67,23 @@ public class RegistrationServiceTest {
     @Mock
     private RestTemplate restTemplate;
 
+    private MockedStatic<RestUtils> restUtilsMockedStatic;
+
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
+        restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class);
+        restUtilsMockedStatic.when(RestUtils::createRestTemplate).thenReturn(restTemplate);
+        ReflectionTestUtils.setField(registrationService, LOCAL_URL, SAMPLE_LOCAL_URL);
+        ReflectionTestUtils.setField(registrationService, DOMAIN_URL, SAMPLE_DOMAIN_URL);
+        ReflectionTestUtils.setField(registrationService, CLIENT_NAME, SAMPLE_CLIENT_NAME);
+        ReflectionTestUtils.setField(registrationService, DESCRIPTION, SAMPLE_DESCRIPTION);
+        ReflectionTestUtils.setField(registrationService, DEEP_LINKING_MENU_LABEL, SAMPLE_DEEP_LINKING_MENU_LABEL);
+    }
+
+    @AfterEach
+    public void close() {
+        restUtilsMockedStatic.close();
     }
 
     @Test
@@ -106,4 +145,48 @@ public class RegistrationServiceTest {
         verify(exceptionMessageGenerator).exceptionMessage(any(String.class), any(Exception.class));
     }
 
+    @Test
+    public void testGenerateToolConfiguration() {
+        PlatformRegistrationDTO platformRegistration = new PlatformRegistrationDTO();
+        List<String> customClaims = List.of("custom-claim-1", "custom-claim-2");
+        platformRegistration.setClaims_supported(customClaims);
+        platformRegistration.setScopes_supported(TEST_SCOPES);
+        platformRegistration.setRegistration_endpoint(TEST_REGISTRATION_ENDPOINT);
+        platformRegistration.setIssuer(TEST_PLATFORM_ISSUER);
+
+        ToolRegistrationDTO toolRegistration = registrationService.generateToolConfiguration(platformRegistration);
+
+        // Validate required constants set
+        assertEquals("web", toolRegistration.getApplication_type());
+        assertTrue(toolRegistration.getGrant_types().containsAll(List.of("implicit", "client_credentials")));
+        assertEquals("id_token", toolRegistration.getResponse_types().get(0));
+        assertEquals("private_key_jwt", toolRegistration.getToken_endpoint_auth_method());
+
+        // Validate tool urls/data set
+        assertEquals(SAMPLE_LOCAL_URL + LTI3_SUFFIX, toolRegistration.getRedirect_uris().get(0));
+        assertEquals(SAMPLE_LOCAL_URL + "/oidc/login_initiations", toolRegistration.getInitiate_login_uri());
+        assertEquals(SAMPLE_CLIENT_NAME, toolRegistration.getClient_name());
+        assertEquals(SAMPLE_LOCAL_URL + "/jwks/jwk", toolRegistration.getJwks_uri());
+        ToolConfigurationDTO toolConfiguration = toolRegistration.getToolConfiguration();
+        assertEquals(SAMPLE_DOMAIN_URL, toolConfiguration.getDomain());
+        assertEquals(SAMPLE_DOMAIN_URL, toolConfiguration.getTarget_link_uri());
+        assertEquals(SAMPLE_DESCRIPTION, toolConfiguration.getDescription());
+
+        // Validate tool supports Deep Linking
+        List<ToolMessagesSupportedDTO> toolMessagesSupportedList = toolConfiguration.getMessages_supported();
+        ToolMessagesSupportedDTO deepLinkingMessageSupported = toolMessagesSupportedList.get(0);
+        assertEquals("LtiDeepLinkingRequest", deepLinkingMessageSupported.getType());
+        assertEquals(SAMPLE_LOCAL_URL + LTI3_SUFFIX, deepLinkingMessageSupported.getTarget_link_uri());
+        assertEquals(SAMPLE_DEEP_LINKING_MENU_LABEL, deepLinkingMessageSupported.getLabel());
+
+        // Validate tool supports LTI Core SSO Standard Launch (aka LtiResourceLinkRequest)
+        ToolMessagesSupportedDTO resourceLinkMessageSupported = toolMessagesSupportedList.get(1);
+        assertEquals("LtiResourceLinkRequest", resourceLinkMessageSupported.getType());
+        assertEquals(SAMPLE_LOCAL_URL + LTI3_SUFFIX, resourceLinkMessageSupported.getTarget_link_uri());
+
+        // Validate tool accepts the claims and scopes from the platform
+        assertTrue(toolConfiguration.getClaims().containsAll(LTI_OPTIONAL_CLAIMS));
+        assertTrue(toolConfiguration.getClaims().containsAll(customClaims));
+        assertEquals("example-scope1 example-scope2", toolRegistration.getScope());
+    }
 }


### PR DESCRIPTION
## Description
I updated the code to enable deep linking by default via Dynamic Registration, and I improved the debug logging statements for this code. I also researched the options for setting the deep linking menu dimensions during the configuration process and documented my findings in comments in the Jira ticket. Unfortunately, the deep linking menu dimensions cannot be set via Dynamic Registration, so I did not make any code changes for that.

### Motivation and Context
This allows for there to be a lot fewer steps for admins who are configuring the Lumen tool to work with deep linking.

### Fixes
[DL3-40](https://lumenlearning.atlassian.net/browse/DL3-40)

## How Has This Been Tested?
### In D2L:
1. Ensure that all of the environment variables for configuring the tool have unique values to the LMS.
2. Navigate to the LMS's Dynamic Registration page.
3. Enter the lti-middleware's Dynamic Registration URL (e.g. https://47a2-184-101-29-219.ngrok.io/registration)
4. Click the button to trigger the dynamic registration process.
5. Wait for the screen that flashes to disappear.
6. Click on the new tool configuration in D2L.
7. Click on the Enable toggle to enable the tool.
8. Ensure that the form is filled out correctly with the values that were set in the environment variables.
9. Scroll to the bottom and click Save.
10. Copy your registration information from the bottom of this page and provide it to someone who can register the tool.
11. Click on the View Deployments link at the bottom of the page.
12. Find the corresponding tool deployment in the table and click on it.
13. If not already, click on the Enable toggle to enable the tool.
14. Scroll to the bottom of the page and click Add Org Units.
15. Select the department or course for which you would like to give access to the tool.
16. Click Save.
17. Copy your Deployment Id from the bottom of this page and provide it to someone who can register the tool.
18. Click on the View Links link at the bottom of the page.
19. Two links should exist in the table. One of them should have the value of `application.name` from the environment variables and the other should have the value of `application.deep.linking.menu.label` from the environment variables.
20. If you would like to change the size of the deep linking menu, click on the one that has the value of `application.deep.linking.menu.label`.
21. Scroll to the middle of the page and enter a value like 1000 for the width and 600 for the height.
22. Scroll down and click Save.
23. Ensure that you have provided your registration information to someone who was able to register the tool for you.
24. Navigate to a course in the LMS which corresponds to the Org Units you added to the deployment in a previous step.
25. Create a module in this course.
26. Click on the Existing Activities dropdown.
27. Confirm that there is an option for the value that is set in `application.deep.linking.menu.label` and click on it.
28. Ensure that the deep linking menu opens and functions as expected.
### In Moodle:
1. Ensure that all of the environment variables for configuring the tool have unique values to the LMS.
2. Navigate to the LMS's Dynamic Registration page.
3. Enter the lti-middleware's Dynamic Registration URL (e.g. https://47a2-184-101-29-219.ngrok.io/registration)
4. Click the button to trigger the dynamic registration process.
5. Wait for the screen that flashes to disappear.
7. Click on the Activate button to enable the tool.
8. Click on the icon to review the registration form that was pre-filled via dynamic registration.
9. Ensure that the form is filled out correctly with the values that were set in the environment variables.
10. Return to the page that lists the tools and click on the icon to view the registration information.
11. Copy your registration information from the pop-up and provide it to someone who can register the tool.
12. Navigate to a course in the LMS and open the menu for selecting content from the LMS.
13. Confirm that there is an option for the value that is set in `application.name` and not `application.deep.linking.menu.label` (Moodle doesn't support a separate Deep Linking menu label) and click on it.
29. Ensure that the deep linking menu opens and functions as expected.

## Screenshots
N/A

---
## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
<!-- Make note of any unique-to-this-PR deployment instructions here. -->

## New ENV variables
The following env variable was added and will need to be set in AWS. I recommend giving it an environment specific value. The default value for the Deep Linking menu name is "Lumen Content Selector". This environment variable corresponds to the value that is visible inside the D2L LMS after clicking on the "Existing Activities" dropdown.
`application.deep.linking.menu.label=${LTI_MIDDLEWARE_DL_LABEL:Lumen Content Selector}`

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
