### PR TITLE
DL3-76 Returning User workflow- bread crumb and Cancel button improvements

### DIFF
--- a/src/main/frontend/src/app/appSlice.js
+++ b/src/main/frontend/src/app/appSlice.js
@@ -27,10 +27,6 @@ export const appSlice = createSlice({
     },
     changeSelectedCourse: (state, action) => {
       state.selectedCourse = action.payload;
-      if (action.payload === null) {
-        // This is important, when the course selection is being restored in the UI we must start over.
-        state.root_outcome_guid = null;
-      }
     },
     setErrorFetchingCourses: (state, action) => {
       state.errorFetchingCourses = action.payload;
@@ -167,6 +163,11 @@ export const fetchSingleCourse = (rootOutcomeGuid) => (dispatch, getState) => {
     // When there's an error fetching courses we must notify the components.
     dispatch(setErrorAssociatingCourse(true));
     console.error(reason);
+    // This is useful for local development purposes, load some dummy data instead of the error message.
+    if (window.location.href.includes('localhost')) {
+      dispatch(changeSelectedCourse(DUMMY_DATA.records[0]));
+      dispatch(setErrorAssociatingCourse(false));
+    }
   }).finally(() => {
     // Remove the spinner once the request has been resolved.
     dispatch(setLoading(false));

--- a/src/main/frontend/src/features/CoursePreview.js
+++ b/src/main/frontend/src/features/CoursePreview.js
@@ -42,6 +42,9 @@ function CoursePreview(props) {
   // Check if the user has selected any module, the Add button must be disabled if there's no selection.
   const hasSelectedModules = Array.isArray(selectedModules) && selectedModules.length > 0;
 
+  // A returning user means a user that previously associated a course with the LMS course, exists a previous root_outcome_guid selection.
+  const isReturningUser = rootOutcomeGuid !== null;
+
   // Some courses may not have a valid cover image, use a default instead
   const courseCoverUrl = parseCourseCoverImage(props.course.cover_img_url, true);
   const dispatch = useDispatch();
@@ -54,9 +57,9 @@ function CoursePreview(props) {
 
   // The 'Select All' checkbox is controlled and depends on the state, enables or disables all the modules at the same time.
   // If the course has not been paired with a Lumen course, 'Select All' must be checked.
-  const [selectAllChecked, setSelectAllChecked] = useState(rootOutcomeGuid === null);
+  const [selectAllChecked, setSelectAllChecked] = useState(!isReturningUser);
   // If the course has been paired with a Lumen course we must display a different text for the button.
-  const addButtonText = rootOutcomeGuid === null ? 'Add Course' : 'Add Content';
+  const addButtonText = !isReturningUser ? 'Add Course' : 'Add Content';
 
   // When the user clicks cancel it should reset the module and the course selection.
   const resetSelection = () => {
@@ -168,7 +171,7 @@ function CoursePreview(props) {
       <div className="fixed-bottom course-footer d-flex flex-row">
           <p className="action-info">Clicking Add Course will add all of the content for this Lumen course to your LMS</p>
           <div className="ms-auto mx-3 d-flex d-row">
-            <Button variant="secondary" onClick={(e) => resetSelection()}>Cancel</Button>
+            {!isReturningUser && <Button variant="secondary" onClick={(e) => resetSelection()}>Cancel</Button>}
             <Button disabled={!hasSelectedModules} variant="primary" className="ms-1" onClick={(e) => addCourseToLMS()}>{addButtonText}</Button>
           </div>
       </div>

--- a/src/main/frontend/src/features/LtiBreadcrumb.js
+++ b/src/main/frontend/src/features/LtiBreadcrumb.js
@@ -1,7 +1,12 @@
 // Redux imports
 import { useDispatch, useSelector } from 'react-redux';
 // Store imports
-import { changeSelectedCourse, selectSelectedCourse, toggleAllModules } from '../app/appSlice';
+import {
+  changeSelectedCourse,
+  selectSelectedCourse,
+  selectRootOutcomeGuid,
+  toggleAllModules
+} from '../app/appSlice';
 // Component imports
 import Breadcrumb from 'react-bootstrap/Breadcrumb';
 
@@ -9,10 +14,16 @@ function LtiBreadcrumb(props) {
 
   const dispatch = useDispatch();
   const selectedCourse = useSelector(selectSelectedCourse);
+  const rootOutcomeGuid = useSelector(selectRootOutcomeGuid);
 
   const resetSelection = () => {
     dispatch(changeSelectedCourse(null));
     dispatch(toggleAllModules(0));
+  }
+
+  // When a course has been paired with the LMS, do not display the breadcrumb so the user cannot go back and select a different course.
+  if (rootOutcomeGuid !== null) {
+    return <></>;
   }
 
   return (

--- a/src/main/frontend/src/features/LtiBreadcrumb.js
+++ b/src/main/frontend/src/features/LtiBreadcrumb.js
@@ -16,21 +16,24 @@ function LtiBreadcrumb(props) {
   const selectedCourse = useSelector(selectSelectedCourse);
   const rootOutcomeGuid = useSelector(selectRootOutcomeGuid);
 
+  // A returning user means a user that previously associated a course with the LMS course, exists a previous root_outcome_guid selection.
+  // When a course has been paired with the LMS, do not display the breadcrumb so the user cannot go back and select a different course.
+  const isReturningUser = rootOutcomeGuid !== null;
+
   const resetSelection = () => {
     dispatch(changeSelectedCourse(null));
     dispatch(toggleAllModules(0));
   }
 
-  // When a course has been paired with the LMS, do not display the breadcrumb so the user cannot go back and select a different course.
-  if (rootOutcomeGuid !== null) {
-    return <></>;
-  }
-
   return (
     <Breadcrumb role="navigation">
-      <Breadcrumb.Item onClick={(e) => resetSelection()}>Lumen Learning</Breadcrumb.Item>
-      <Breadcrumb.Item active={!selectedCourse} onClick={(e) => resetSelection()}>Add Course</Breadcrumb.Item>
-      {selectedCourse && <Breadcrumb.Item active>{selectedCourse.book_title}</Breadcrumb.Item>}
+      {!isReturningUser &&
+        <>
+          <Breadcrumb.Item onClick={(e) => resetSelection()}>Lumen Learning</Breadcrumb.Item>
+          <Breadcrumb.Item active={!selectedCourse} onClick={(e) => resetSelection()}>Add Course</Breadcrumb.Item>
+          {selectedCourse && <Breadcrumb.Item active>{selectedCourse.book_title}</Breadcrumb.Item>}
+        </>
+      }
     </Breadcrumb>
   );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including your Jira ticket ID. -->

## Description
When a course has been paired with the LMS and the user wants to add modules, it should skip the course catalog page. This PR also removes the breadcrumb and the cancel button so the user cannot select a different course.

### Motivation and Context
It will prevent the user to cancel or go to the course catalog using the breadcrumb links.

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/DL3-76)

## How Has This Been Tested?
Tested locally simulating the conditions and tested using D2L with a previously associated course.

## Screenshots
In the following video the user access a linked course, displays the course preview and the breadcrumb and the cancel buttons are not present.

![DL3-76](https://user-images.githubusercontent.com/8653754/187646550-e97b47dc-a75d-45f4-ba8b-ce30f77269ec.gif)

---
<!-- The following section calls out any changes that will impact the deploy of this PR and/or need to be shared with the team post-deploy. It is not meant to be all-inclusive; if there are additional things to note here, make a heading and do so :) -->

## Database changes
<!-- Describe any database changes here. -->

## ⚠️ Deployment instructions ⚠️
<!-- Make note of any unique-to-this-PR deployment instructions here. -->

## New ENV variables
<!-- Document any new ENV variables added as part of this work -->

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the AC for this feature and my changes meet all requirements
- [X] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have requested a review from at least one other dev
