### PR TITLE
DL3-79 Disable the Add Course button in Course Preview, unless user c…

### DIFF
--- a/src/main/frontend/src/features/CoursePreview.js
+++ b/src/main/frontend/src/features/CoursePreview.js
@@ -39,6 +39,9 @@ function CoursePreview(props) {
   const rootOutcomeGuid = useSelector(selectRootOutcomeGuid);
   const selectedModules = useSelector(selectSelectedModules);
 
+  // Check if the user has selected any module, the Add button must be disabled if there's no selection.
+  const hasSelectedModules = Array.isArray(selectedModules) && selectedModules.length > 0;
+
   // Some courses may not have a valid cover image, use a default instead
   const courseCoverUrl = parseCourseCoverImage(props.course.cover_img_url, true);
   const dispatch = useDispatch();
@@ -166,7 +169,7 @@ function CoursePreview(props) {
           <p className="action-info">Clicking Add Course will add all of the content for this Lumen course to your LMS</p>
           <div className="ms-auto mx-3 d-flex d-row">
             <Button variant="secondary" onClick={(e) => resetSelection()}>Cancel</Button>
-            <Button variant="primary" className="ms-1" onClick={(e) => addCourseToLMS()}>{addButtonText}</Button>
+            <Button disabled={!hasSelectedModules} variant="primary" className="ms-1" onClick={(e) => addCourseToLMS()}>{addButtonText}</Button>
           </div>
       </div>
   </>


### PR DESCRIPTION
…hecks at least one module

<!--- Provide a general summary of your changes in the Title above, including your Jira ticket ID. -->

## Description
The user can add a course or content without selecting any module, pairing the course accidentally. This change disables the button when the user has not selected any module.

### Motivation and Context
Resolves a potential issue that the user pairs an empty selection by mistake.

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/DL3-79)

## How Has This Been Tested?
Tested using D2L and both workflows, when the user is pairing the course and a returning user with an already paired course.

## Screenshots

Videos of both situations showing the behavior of the button.

![DL3-79-new](https://user-images.githubusercontent.com/8653754/187852844-eb81394f-b96b-46df-b797-114abe567478.gif)

![DL3-79-paired](https://user-images.githubusercontent.com/8653754/187852849-c2fcc1d4-c763-406c-a8a7-9df8a64dcd8f.gif)



---
<!-- The following section calls out any changes that will impact the deploy of this PR and/or need to be shared with the team post-deploy. It is not meant to be all-inclusive; if there are additional things to note here, make a heading and do so :) -->

## Database changes
<!-- Describe any database changes here. -->

## ⚠️ Deployment instructions ⚠️
<!-- Make note of any unique-to-this-PR deployment instructions here. -->

## New ENV variables
<!-- Document any new ENV variables added as part of this work -->

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the AC for this feature and my changes meet all requirements
- [X] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have requested a review from at least one other dev
