### PR TITLE
LA-260: Create an association between the LTI 1.3 middleware configur…

### DIFF
--- a/src/main/java/net/unicon/lti/controller/lti/ConfigurationController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/ConfigurationController.java
@@ -107,6 +107,7 @@ public class ConfigurationController {
         platformDeploymentToChange.setIss(platformDeployment.getIss());
         platformDeploymentToChange.setOidcEndpoint(platformDeployment.getOidcEndpoint());
         platformDeploymentToChange.setJwksEndpoint(platformDeployment.getJwksEndpoint());
+        platformDeploymentToChange.setLumenAdminId(platformDeployment.getLumenAdminId());
 
         platformDeploymentRepository.saveAndFlush(platformDeploymentToChange);
         return new ResponseEntity<>(platformDeploymentToChange, HttpStatus.OK);

--- a/src/main/java/net/unicon/lti/model/PlatformDeployment.java
+++ b/src/main/java/net/unicon/lti/model/PlatformDeployment.java
@@ -55,6 +55,9 @@ public class PlatformDeployment extends BaseEntity {
     @Basic
     @Column(name = "deployment_id")
     private String deploymentId;  // Where in the platform we need to ask for the oidc authentication.
+    @Basic
+    @Column(name = "lumen_admin_id")
+    private String lumenAdminId;
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @OneToMany(mappedBy = "platformDeployment", fetch = FetchType.LAZY)
@@ -123,6 +126,14 @@ public class PlatformDeployment extends BaseEntity {
 
     public void setDeploymentId(String deploymentId) {
         this.deploymentId = deploymentId;
+    }
+
+    public String getLumenAdminId() {
+        return lumenAdminId;
+    }
+
+    public void setLumenAdminId(String lumenAdminId) {
+        this.lumenAdminId = lumenAdminId;
     }
 
     @JsonIgnore

--- a/src/main/java/net/unicon/lti/model/PlatformDeployment.java
+++ b/src/main/java/net/unicon/lti/model/PlatformDeployment.java
@@ -57,7 +57,7 @@ public class PlatformDeployment extends BaseEntity {
     private String deploymentId;  // Where in the platform we need to ask for the oidc authentication.
     @Basic
     @Column(name = "lumen_admin_id")
-    private String lumenAdminId;
+    private String lumenAdminId; // Points back to the institution (in Lumen Admin) to which this configuration belongs
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @OneToMany(mappedBy = "platformDeployment", fetch = FetchType.LAZY)


### PR DESCRIPTION
…ations and institutions

## Description
- update model to add lumen_admin_id (liquibase does magic to add to the schema)
- update controller method for the post to update lumenAdminId

### Motivation and Context
This pairs with the work done in Lumen Admin to connect LTI 1.3 configurations to the Institutions. Will be nice for debugging from the middleware if we need to connect back to an institution. Also useful for extra configurations in LA

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/LA-260)

## How Has This Been Tested?
Created a new PlatformDeployment/Configuration via the API with a lumen_admin_id

## Screenshots
N/A

## Database changes
added lumen_admin_id column to iss_configuration table

## ⚠️ Deployment instructions ⚠️
deploy before the LA rc/ipswich branch is deployed

## New ENV variables
N/A

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [ ] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
