### PR TITLE
DL3-86 Indicate if the LMS is Canvas to the front end for dynamic iframe sizing

### DIFF
--- a/src/main/frontend/public/index.html
+++ b/src/main/frontend/public/index.html
@@ -18,7 +18,8 @@
           clientId: '[[${clientId}]]',
           iss: '[[${iss}]]',
           context: '[[${context}]]',
-          root_outcome_guid: '[[${root_outcome_guid}]]'
+          root_outcome_guid: '[[${root_outcome_guid}]]',
+          isCanvas: '[[${isCanvas}]]'
         };
         <!--/* We have to set an attribute to the root element so the APP can use the values of the LTI launch data. */-->
         document.getElementById('root').setAttribute('lti-launch-data', JSON.stringify(ltiLaunchData));

--- a/src/main/frontend/public/index.html
+++ b/src/main/frontend/public/index.html
@@ -19,7 +19,7 @@
           iss: '[[${iss}]]',
           context: '[[${context}]]',
           root_outcome_guid: '[[${root_outcome_guid}]]',
-          isCanvas: '[[${isCanvas}]]'
+          platform_family_code: '[[${platform_family_code}]]'
         };
         <!--/* We have to set an attribute to the root element so the APP can use the values of the LTI launch data. */-->
         document.getElementById('root').setAttribute('lti-launch-data', JSON.stringify(ltiLaunchData));

--- a/src/main/frontend/src/index.js
+++ b/src/main/frontend/src/index.js
@@ -45,8 +45,6 @@ const initialState = {
   root_outcome_guid: isValidRootOutcomeGuid(ltiLaunchData.root_outcome_guid) ? ltiLaunchData.root_outcome_guid : null,
   platform_family_code: ltiLaunchData.platform_family_code
 };
-console.log("platform_family_code:");
-console.log(initialState.platform_family_code);
 
 // Creates the store and preloads the initial state of the store.
 const store = configureStore({

--- a/src/main/frontend/src/index.js
+++ b/src/main/frontend/src/index.js
@@ -43,6 +43,7 @@ const initialState = {
   state: ltiLaunchData.state,
   target: ltiLaunchData.target,
   root_outcome_guid: isValidRootOutcomeGuid(ltiLaunchData.root_outcome_guid) ? ltiLaunchData.root_outcome_guid : null,
+  isCanvas: ltiLaunchData.isCanvas
 };
 
 // Creates the store and preloads the initial state of the store.

--- a/src/main/frontend/src/index.js
+++ b/src/main/frontend/src/index.js
@@ -43,8 +43,10 @@ const initialState = {
   state: ltiLaunchData.state,
   target: ltiLaunchData.target,
   root_outcome_guid: isValidRootOutcomeGuid(ltiLaunchData.root_outcome_guid) ? ltiLaunchData.root_outcome_guid : null,
-  isCanvas: ltiLaunchData.isCanvas
+  platform_family_code: ltiLaunchData.platform_family_code
 };
+console.log("platform_family_code:");
+console.log(initialState.platform_family_code);
 
 // Creates the store and preloads the initial state of the store.
 const store = configureStore({

--- a/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
@@ -154,7 +154,7 @@ public class LTI3Controller {
                 model.addAttribute("target", target);
                 model.addAttribute("id_token", middlewareIdToken);
                 model.addAttribute("state", state);
-                model.addAttribute("isCanvas", StringUtils.equals("canvas", lti3Request.getLtiToolPlatformFamilyCode()));
+                model.addAttribute("platform_family_code", lti3Request.getLtiToolPlatformFamilyCode());
             } else {
                 model.addAttribute("target", ltiDataService.getLocalUrl() + "/demo?link=" + link);
                 return "lti3Redirect";

--- a/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
@@ -154,6 +154,7 @@ public class LTI3Controller {
                 model.addAttribute("target", target);
                 model.addAttribute("id_token", middlewareIdToken);
                 model.addAttribute("state", state);
+                model.addAttribute("isCanvas", StringUtils.equals("canvas", lti3Request.getLtiToolPlatformFamilyCode()));
             } else {
                 model.addAttribute("target", ltiDataService.getLocalUrl() + "/demo?link=" + link);
                 return "lti3Redirect";

--- a/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
@@ -154,6 +154,7 @@ public class LTI3ControllerTest {
             when(lti3Request.getLtiTargetLinkUrl()).thenReturn("https://tool.com/test");
             when(lti3Request.getLtiMessageType()).thenReturn(LtiStrings.LTI_MESSAGE_TYPE_RESOURCE_LINK);
             when(lti3Request.getLtiContextId()).thenReturn(SAMPLE_LTI_CONTEXT_ID);
+            when(lti3Request.getLtiToolPlatformFamilyCode()).thenReturn("canvas");
             when(platformDeploymentRepository.findByIssAndClientIdAndDeploymentId(any(String.class), any(String.class), any(String.class))).thenReturn(List.of(platformDeployment));
             ltiContext.setLineitems(SAMPLE_LINEITEMS_URL);
             when(ltiContextRepository.findByContextKeyAndPlatformDeployment(eq(SAMPLE_LTI_CONTEXT_ID), eq(platformDeployment))).thenReturn(ltiContext);
@@ -244,6 +245,7 @@ public class LTI3ControllerTest {
             assertEquals(model.getAttribute("target"), "https://tool.com/test");
             String finalIdToken = (String) model.getAttribute("id_token");
             assertNotEquals(finalIdToken, ID_TOKEN);
+            assertTrue((Boolean) model.getAttribute("isCanvas"));
 
             // validate that final jwt was signed by middleware
             Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(finalIdToken);
@@ -299,6 +301,7 @@ public class LTI3ControllerTest {
             String finalIdToken = (String) model.getAttribute("id_token");
             assertEquals(finalIdToken, middlewareIdTokenCaptor.getValue());
             assertNotEquals(finalIdToken, ID_TOKEN);
+            assertTrue((Boolean) model.getAttribute("isCanvas"));
 
             // validate that final jwt was signed by middleware
             Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(finalIdToken);
@@ -331,6 +334,7 @@ public class LTI3ControllerTest {
             String finalIdToken = (String) model.getAttribute("id_token");
             assertEquals(finalIdToken, middlewareIdTokenCaptor.getValue());
             assertNotEquals(finalIdToken, ID_TOKEN);
+            assertTrue((Boolean) model.getAttribute("isCanvas"));
 
             // validate that final jwt was signed by middleware
             Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(finalIdToken);
@@ -439,6 +443,7 @@ public class LTI3ControllerTest {
             assertEquals(model.getAttribute(TARGET), SAMPLE_TARGET);
             String finalIdToken = (String) model.getAttribute(ID_TOKEN);
             assertNotEquals(finalIdToken, SAMPLE_ID_TOKEN);
+            assertTrue((Boolean) model.getAttribute("isCanvas"));
             // validate that final jwt was signed by middleware
             Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(finalIdToken);
             assertNotNull(finalClaims);
@@ -470,6 +475,7 @@ public class LTI3ControllerTest {
             String finalIdToken = (String) model.getAttribute(ID_TOKEN);
             assertEquals(finalIdToken, middlewareIdTokenCaptor.getValue());
             assertNotEquals(finalIdToken, ID_TOKEN);
+            assertTrue((Boolean) model.getAttribute("isCanvas"));
 
             // validate that final jwt was signed by middleware
             Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(finalIdToken);
@@ -532,6 +538,7 @@ public class LTI3ControllerTest {
             assertEquals(model.getAttribute("root_outcome_guid"), "root-outcome-guid-1");
             String finalIdToken = (String) model.getAttribute(ID_TOKEN);
             assertNotEquals(finalIdToken, SAMPLE_ID_TOKEN);
+            assertTrue((Boolean) model.getAttribute("isCanvas"));
             // validate that final jwt was signed by middleware
             Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(finalIdToken);
             assertNotNull(finalClaims);

--- a/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
@@ -74,6 +74,8 @@ public class LTI3ControllerTest {
     private static final String SAMPLE_ISS = "https://lms.com";
     private static final String SAMPLE_TARGET = "https://tool.com/test";
     private static final String TARGET = "target";
+    private static final String CANVAS = "canvas";
+    private static final String PLATFORM_FAMILY_CODE = "platform_family_code";
 
     @InjectMocks
     private LTI3Controller lti3Controller = new LTI3Controller();
@@ -245,7 +247,7 @@ public class LTI3ControllerTest {
             assertEquals(model.getAttribute("target"), "https://tool.com/test");
             String finalIdToken = (String) model.getAttribute("id_token");
             assertNotEquals(finalIdToken, ID_TOKEN);
-            assertTrue((Boolean) model.getAttribute("isCanvas"));
+            assertEquals(CANVAS, model.getAttribute(PLATFORM_FAMILY_CODE));
 
             // validate that final jwt was signed by middleware
             Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(finalIdToken);
@@ -301,7 +303,7 @@ public class LTI3ControllerTest {
             String finalIdToken = (String) model.getAttribute("id_token");
             assertEquals(finalIdToken, middlewareIdTokenCaptor.getValue());
             assertNotEquals(finalIdToken, ID_TOKEN);
-            assertTrue((Boolean) model.getAttribute("isCanvas"));
+            assertEquals(CANVAS, model.getAttribute(PLATFORM_FAMILY_CODE));
 
             // validate that final jwt was signed by middleware
             Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(finalIdToken);
@@ -334,7 +336,7 @@ public class LTI3ControllerTest {
             String finalIdToken = (String) model.getAttribute("id_token");
             assertEquals(finalIdToken, middlewareIdTokenCaptor.getValue());
             assertNotEquals(finalIdToken, ID_TOKEN);
-            assertTrue((Boolean) model.getAttribute("isCanvas"));
+            assertEquals(CANVAS, model.getAttribute(PLATFORM_FAMILY_CODE));
 
             // validate that final jwt was signed by middleware
             Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(finalIdToken);
@@ -443,7 +445,7 @@ public class LTI3ControllerTest {
             assertEquals(model.getAttribute(TARGET), SAMPLE_TARGET);
             String finalIdToken = (String) model.getAttribute(ID_TOKEN);
             assertNotEquals(finalIdToken, SAMPLE_ID_TOKEN);
-            assertTrue((Boolean) model.getAttribute("isCanvas"));
+            assertEquals(CANVAS, model.getAttribute(PLATFORM_FAMILY_CODE));
             // validate that final jwt was signed by middleware
             Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(finalIdToken);
             assertNotNull(finalClaims);
@@ -475,7 +477,7 @@ public class LTI3ControllerTest {
             String finalIdToken = (String) model.getAttribute(ID_TOKEN);
             assertEquals(finalIdToken, middlewareIdTokenCaptor.getValue());
             assertNotEquals(finalIdToken, ID_TOKEN);
-            assertTrue((Boolean) model.getAttribute("isCanvas"));
+            assertEquals(CANVAS, model.getAttribute(PLATFORM_FAMILY_CODE));
 
             // validate that final jwt was signed by middleware
             Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(finalIdToken);
@@ -538,7 +540,7 @@ public class LTI3ControllerTest {
             assertEquals(model.getAttribute("root_outcome_guid"), "root-outcome-guid-1");
             String finalIdToken = (String) model.getAttribute(ID_TOKEN);
             assertNotEquals(finalIdToken, SAMPLE_ID_TOKEN);
-            assertTrue((Boolean) model.getAttribute("isCanvas"));
+            assertEquals(CANVAS, model.getAttribute(PLATFORM_FAMILY_CODE));
             // validate that final jwt was signed by middleware
             Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(finalIdToken);
             assertNotNull(finalClaims);


### PR DESCRIPTION
## Description
Indicate to the middleware front end if the LMS is Canvas to know if dynamic iframe sizing is supported.

### Motivation and Context
This will allow for Canvas's window.postMessage feature to be used to dynamically change the size of the deep linking menu.

### Fixes
[DL3-86](https://lumenlearning.atlassian.net/browse/DL3-86)

## How Has This Been Tested?
1. I added console.log statements to index.js to output the `platform_family_code` variable.
2. I confirmed that when I opened the deep linking menu in Canvas, a value of `canvas` was output to the console.
3. I confirmed that when I opened the deep linking menu in D2L, a value of `desire2learn` was output to the console.

## Screenshots

---

## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
N/A

## New ENV variables
N/A

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
