### PR TITLE
DL3-83 prevent aggressive index caching

### DIFF
--- a/src/main/java/net/unicon/lti/config/WebConfig.java
+++ b/src/main/java/net/unicon/lti/config/WebConfig.java
@@ -46,8 +46,15 @@ public class WebConfig implements WebMvcConfigurer {
                         "classpath:/static/static/css/"
                         );
 
+//        Resource resource = resourceLoader.getResource("classpath:/static/index.html");
+//        if (resource.exists()) {
+//            System.out.println("Resource exists");
+//        } else {
+//            System.out.println("resource does not exist");
+//        }
+
         registry.addResourceHandler("/index.html")
-                .addResourceLocations("classpath:/frontend/public/index.html")
+                .addResourceLocations("classpath:/static/index.html")
                 .setCachePeriod(0);
     }
 

--- a/src/main/java/net/unicon/lti/config/WebConfig.java
+++ b/src/main/java/net/unicon/lti/config/WebConfig.java
@@ -45,6 +45,10 @@ public class WebConfig implements WebMvcConfigurer {
                         "classpath:/static/static/js/",
                         "classpath:/static/static/css/"
                         );
+
+        registry.addResourceHandler("/index.html")
+                .addResourceLocations("classpath:/frontend/public/index.html")
+                .setCachePeriod(0);
     }
 
 }

--- a/src/main/java/net/unicon/lti/config/WebConfig.java
+++ b/src/main/java/net/unicon/lti/config/WebConfig.java
@@ -46,13 +46,6 @@ public class WebConfig implements WebMvcConfigurer {
                         "classpath:/static/static/css/"
                         );
 
-//        Resource resource = resourceLoader.getResource("classpath:/static/index.html");
-//        if (resource.exists()) {
-//            System.out.println("Resource exists");
-//        } else {
-//            System.out.println("resource does not exist");
-//        }
-
         registry.addResourceHandler("/index.html")
                 .addResourceLocations("classpath:/static/index.html")
                 .setCachePeriod(0);


### PR DESCRIPTION
## Description
Preventing caching of the index.html page

### Motivation and Context
This solves the issue of having to clear browser cache after every deployment.

### Fixes
[DL3-83](https://lumenlearning.atlassian.net/browse/DL3-83)

## How Has This Been Tested?
I temporarily inserted code to confirm that the index.html file being referenced exists. Then I deployed this update to the dev-env and confirmed that I was able to initiate the deep linking flow subsequently without getting any errors.

## Screenshots
N/A

---

## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
N/A

## New ENV variables
N/A

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
