### PR TITLE
DL3-4 do not sync lineitems for demo mode

### DIFF
--- a/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
@@ -364,11 +364,10 @@ public class LTI3ControllerTest {
             assertTrue(Objects.requireNonNull(exception.getReason()).contains("Could not fetch lineitems to sync with Harmony"));
 
             // validate lineitems not synced
+            Mockito.verify(ltiDataService).getDemoMode();
             Mockito.verify(advantageAGSService).getLineItems(eq(platformDeployment), eq(SAMPLE_LINEITEMS_URL));
             Mockito.verify(harmonyService, never()).postLineitemsToHarmony(any(LineItems.class), anyString());
             Mockito.verify(ltiContextRepository, never()).save(eq(ltiContext));
-
-            Mockito.verify(ltiDataService, never()).getDemoMode();
         } catch (ConnectionException | JsonProcessingException | DataServiceException e) {
             fail(UNIT_TEST_EXCEPTION_TEXT);
         }
@@ -391,11 +390,10 @@ public class LTI3ControllerTest {
             assertTrue(Objects.requireNonNull(exception.getReason()).contains("Harmony could not receive lineitems"));
 
             // validate lineitems not synced
+            Mockito.verify(ltiDataService).getDemoMode();
             Mockito.verify(advantageAGSService).getLineItems(eq(platformDeployment), eq(SAMPLE_LINEITEMS_URL));
             Mockito.verify(harmonyService).postLineitemsToHarmony(any(LineItems.class), middlewareIdTokenCaptor.capture());
             Mockito.verify(ltiContextRepository, never()).save(eq(ltiContext));
-
-            Mockito.verify(ltiDataService, never()).getDemoMode();
         } catch (ConnectionException | JsonProcessingException | DataServiceException e) {
             fail(UNIT_TEST_EXCEPTION_TEXT);
         }
@@ -412,11 +410,10 @@ public class LTI3ControllerTest {
             Mockito.verify(ltijwtService).validateState(VALID_STATE);
 
             // validate lineitems synced
+            Mockito.verify(ltiDataService).getDemoMode();
             Mockito.verify(advantageAGSService).getLineItems(eq(platformDeployment), eq(SAMPLE_LINEITEMS_URL));
             Mockito.verify(harmonyService).postLineitemsToHarmony(any(LineItems.class), middlewareIdTokenCaptor.capture());
             Mockito.verify(ltiContextRepository, never()).save(eq(ltiContext));
-
-            Mockito.verify(ltiDataService, never()).getDemoMode();
 
             assertEquals("Harmony Lineitems API returned 500 INTERNAL_SERVER_ERROR\nnull", model.getAttribute("Error"));
 
@@ -499,13 +496,12 @@ public class LTI3ControllerTest {
 
             Mockito.verify(ltijwtService).validateState(VALID_STATE);
 
-            // validate lineitems synced
-            Mockito.verify(advantageAGSService).getLineItems(eq(platformDeployment), eq(SAMPLE_LINEITEMS_URL));
-            Mockito.verify(harmonyService).postLineitemsToHarmony(any(LineItems.class), middlewareIdTokenCaptor.capture());
-            Mockito.verify(ltiContextRepository).save(eq(ltiContext));
-            assertTrue(ltiContext.getLineitemsSynced());
-
+            // validate lineitems not synced
             Mockito.verify(ltiDataService).getDemoMode();
+            Mockito.verify(advantageAGSService, never()).getLineItems(eq(platformDeployment), eq(SAMPLE_LINEITEMS_URL));
+            Mockito.verify(harmonyService, never()).postLineitemsToHarmony(any(LineItems.class), middlewareIdTokenCaptor.capture());
+            Mockito.verify(ltiContextRepository, never()).save(eq(ltiContext));
+
             assertEquals(finalResponse, "lti3Redirect");
         } catch (JsonProcessingException | DataServiceException | ConnectionException e) {
             fail(UNIT_TEST_EXCEPTION_TEXT);


### PR DESCRIPTION
## Description
Skips syncing lineitems for demo mode since demo links do not correspond to Lumen books.

### Motivation and Context
Without this change, after inserting deep links from the demo picker, it was not possible to complete a standard LTI launch through the inserted links. With this change, the demo mode works as expected.

### Fixes
[DL3-4](https://lumenlearning.atlassian.net/browse/DL3-4)

## How Has This Been Tested?
Using a registered tool enabled in a course in the LMS, I went through the deep linking flow, inserted links, clicked on one of the links, went through the standard launch flow, opened the Memberships service and opened the AGS service, added an assignment using the AGS service.

## Screenshots
N/A
---

## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
N/A

## New ENV variables
N/A

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [x] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
