### PR TITLE
DL3-65 remove harmony jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,10 +231,9 @@ lti13.grade-passback-queue=<queue name>
 ## Setup Harmony Courses Endpoint
 
 When there's a deep linking request the LTI tool displays a Harmony course selector to the instructor, the list of courses comes from a Harmony endpoint.
-In order to fetch some courses you'll need credentials to access the endpoint, please complete these properties in the `.properties`
+Please complete this properties in the `.properties`
 ```
-harmony.courses.api=http://localhost:3000/service_api/course_catalog
-harmony.courses.jwt=eyJhbGciOiJIUzUxMiJ9.eyJzY29wZXMiOlsiZnVsbF9zZXJ2aWNlX2FwaV9hY2Nlc3MiLCJtYW5hZ2VfYWNjb3VudHNfYW5kX2F1dGhfY3JlZGVudGlhbHMiLCJydW5fcmVwb3J0cyIsInZpZXdfYWN0aXZhdGlvbl9sb2dzIl0sIm5hbWUiOiJtYXR0aGV3IiwiaWF0IjoxNjU5MTI4NTM2LCJhdWQiOiJ2YWxreXJpZV9zZXJ2aWNlcyJ9.v-cjw6CaHPbTsz8xcwXCm9yyGlTd53oW572val1V7vo3y8Sje8LF-_NURo3r-L8CLF6r05cPo2q8EVau3D5R2Q
+harmony.courses.api=http://localhost:3000/lti/deep_linking
 ```
 
 ## Dynamic Registration

--- a/src/main/java/net/unicon/lti/service/harmony/HarmonyService.java
+++ b/src/main/java/net/unicon/lti/service/harmony/HarmonyService.java
@@ -50,12 +50,9 @@ public class HarmonyService {
     @Value("${harmony.courses.api}")
     private String harmonyCoursesApiUrl;
 
-    @Value("${harmony.courses.jwt}")
-    private String harmonyJWT;
-
     public HarmonyPageResponse fetchHarmonyCourses(Integer page, String rootOutcomeGuid) {
 
-        if (StringUtils.isAnyBlank(harmonyCoursesApiUrl, harmonyJWT)) {
+        if (StringUtils.isBlank(harmonyCoursesApiUrl)) {
             log.warn("The Harmony Courses API has not been configured, courses will not be fetched.");
             return null;
         }
@@ -74,10 +71,7 @@ public class HarmonyService {
             }
 
             String requestUrl = builder.build().toString();
-            HttpHeaders headers = new HttpHeaders();
-            headers.setBearerAuth(harmonyJWT);
-            HttpEntity<String> entity = new HttpEntity<>(headers);
-            ResponseEntity<HarmonyPageResponse> response = restTemplate.exchange(requestUrl, HttpMethod.GET, entity, HarmonyPageResponse.class);
+            ResponseEntity<HarmonyPageResponse> response = restTemplate.getForEntity(requestUrl, HarmonyPageResponse.class);
             if (response.getStatusCode().is2xxSuccessful()) {
                 return response.getBody();
             } else {
@@ -92,7 +86,7 @@ public class HarmonyService {
     }
 
     public List<HarmonyContentItemDTO> fetchDeepLinkingContentItems(String rootOutcomeGuid, String idToken, boolean coursePaired, List moduleIds) {
-        if (StringUtils.isAnyBlank(harmonyCoursesApiUrl, harmonyJWT)) {
+        if (StringUtils.isBlank(harmonyCoursesApiUrl)) {
             log.error("The Harmony API has not been configured, deep links will not be fetched.");
             return null;
         }
@@ -117,10 +111,8 @@ public class HarmonyService {
             requestUrl = builder.build().toString();
             log.debug("About to request deep links from: {}", requestUrl);
 
-            HttpHeaders headers = new HttpHeaders();
-            headers.setBearerAuth(harmonyJWT);
             HarmonyFetchDeepLinksBody body = new HarmonyFetchDeepLinksBody(null, idToken, moduleIds);
-            HttpEntity<HarmonyFetchDeepLinksBody> entity = new HttpEntity<>(body, headers);
+            HttpEntity<HarmonyFetchDeepLinksBody> entity = new HttpEntity<>(body);
 
             ResponseEntity<HarmonyContentItemDTO[]> response = restTemplate.exchange(requestUrl, HttpMethod.POST, entity, HarmonyContentItemDTO[].class);
             if (response.getStatusCode().is2xxSuccessful()) {
@@ -150,7 +142,6 @@ public class HarmonyService {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.setBearerAuth(harmonyJWT);
         Map<String, Object> body = new HashMap<>();
         body.put("id_token", idToken);
         body.put("lineitems", lineItems.getLineItemList());

--- a/src/main/resources/application-aws.properties
+++ b/src/main/resources/application-aws.properties
@@ -66,4 +66,3 @@ terracotta.admin.user = admin
 
 # Harmony Courses API credentials
 harmony.courses.api=
-harmony.courses.jwt=

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -102,4 +102,3 @@ terracotta.admin.user = admin
 
 # Harmony Courses API credentials
 harmony.courses.api=
-harmony.courses.jwt=

--- a/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
@@ -33,7 +33,6 @@ import org.springframework.web.client.RestTemplate;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -48,8 +47,6 @@ import static org.mockito.Mockito.when;
 public class HarmonyServiceTest {
     private final String MOCK_SERVER_URL = "http://localhost:1080";
     private final String MOCK_SERVER_LINEITEMS_URL = MOCK_SERVER_URL + "/lineitems";
-    private final String MOCK_HARMONY_JWT = "mock-harmony-jwt";
-    private final String HARMONY_JWT = "harmonyJWT";
     private final String HARMONY_COURSES_API_URL = "harmonyCoursesApiUrl";
     private final String SAMPLE_ROOT_OUTCOME_GUID = "root";
     private final String SAMPLE_ID_TOKEN = "sample-id-token";
@@ -66,7 +63,6 @@ public class HarmonyServiceTest {
     public void setUp() {
         MockitoAnnotations.openMocks(this);
         ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
         restUtilsMockedStatic = Mockito.mockStatic(RestUtils.class);
         restUtilsMockedStatic.when(RestUtils::createRestTemplate).thenReturn(restTemplate);
     }
@@ -77,40 +73,14 @@ public class HarmonyServiceTest {
     }
 
     @Test
-    public void testNullCredentials() {
-        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, null);
-        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, null);
-        assertNull(harmonyService.fetchHarmonyCourses(1, null));
-    }
-
-    @Test
-    public void testEmptyCredentials() {
-        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "");
-        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, "");
-        assertNull(harmonyService.fetchHarmonyCourses(1, null));
-    }
-
-    @Test
     public void testNullUrl() {
         ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, null);
         assertNull(harmonyService.fetchHarmonyCourses(1, null));
     }
 
     @Test
-    public void testNullToken() {
-        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, null);
-        assertNull(harmonyService.fetchHarmonyCourses(1, null));
-    }
-
-    @Test
     public void testEmptyUrl() {
         ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "");
-        assertNull(harmonyService.fetchHarmonyCourses(1, null));
-    }
-
-    @Test
-    public void testEmptyToken() {
-        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, "");
         assertNull(harmonyService.fetchHarmonyCourses(1, null));
     }
 
@@ -162,7 +132,7 @@ public class HarmonyServiceTest {
         harmonyPageResponse.setRecords(List.of(harmonyCourse));
         harmonyPageResponse.setMetadata(harmonyMetadata);
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(harmonyPageResponse, HttpStatus.OK);
-        when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
+        when(restTemplate.getForEntity(eq(MOCK_SERVER_URL), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
 
         HarmonyPageResponse serviceResponse = harmonyService.fetchHarmonyCourses(1, null);
         assertNotNull(serviceResponse);
@@ -182,12 +152,12 @@ public class HarmonyServiceTest {
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(new HarmonyPageResponse(), HttpStatus.OK);
         // Ensure that the service requests the right page
         // When requesting the default it returns null.
-        when(restTemplate.exchange(eq(MOCK_SERVER_URL), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(null);
+        when(restTemplate.getForEntity(eq(MOCK_SERVER_URL), eq(HarmonyPageResponse.class))).thenReturn(null);
         // The typo in the page attribute is introduced on purpose to verify the parameter.
-        when(restTemplate.exchange(eq(MOCK_SERVER_URL + "?p_ag_e=3"), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
+        when(restTemplate.getForEntity(eq(MOCK_SERVER_URL + "?p_ag_e=3"), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
         // When requesting the second or the fourth page it returns a response.
-        when(restTemplate.exchange(eq(MOCK_SERVER_URL + "?page=2"), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
-        when(restTemplate.exchange(eq(MOCK_SERVER_URL + "?page=4"), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
+        when(restTemplate.getForEntity(eq(MOCK_SERVER_URL + "?page=2"), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
+        when(restTemplate.getForEntity(eq(MOCK_SERVER_URL + "?page=4"), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
 
         // These pages do not include the response
         assertNull(harmonyService.fetchHarmonyCourses(1, null));
@@ -215,7 +185,7 @@ public class HarmonyServiceTest {
         harmonyPageResponse.setRecords(List.of(harmonyCourse));
         harmonyPageResponse.setMetadata(harmonyMetadata);
         ResponseEntity<HarmonyPageResponse> responseEntity = new ResponseEntity<>(harmonyPageResponse, HttpStatus.OK);
-        when(restTemplate.exchange(eq(MOCK_SERVER_URL + "?root_outcome_guid=root"), eq(HttpMethod.GET), any(HttpEntity.class), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
+        when(restTemplate.getForEntity(eq(MOCK_SERVER_URL + "?root_outcome_guid=root"), eq(HarmonyPageResponse.class))).thenReturn(responseEntity);
 
         HarmonyPageResponse serviceResponse = harmonyService.fetchHarmonyCourses(1, "root");
         assertNotNull(serviceResponse);
@@ -231,40 +201,14 @@ public class HarmonyServiceTest {
     }
 
     @Test
-    public void testNullCredentialsForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, null);
-        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, null);
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_ID_TOKEN, false, null));
-    }
-
-    @Test
-    public void testEmptyCredentialsForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "");
-        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, "");
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_ID_TOKEN, false, null));
-    }
-
-    @Test
     public void testNullUrlForFetchDeepLinkingContentItems() {
         ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, null);
         assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_ID_TOKEN, false, null));
     }
 
     @Test
-    public void testNullTokenForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, null);
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_ID_TOKEN, false, null));
-    }
-
-    @Test
     public void testEmptyUrlForFetchDeepLinkingContentItems() {
         ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "");
-        assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_ID_TOKEN, false, null));
-    }
-
-    @Test
-    public void testEmptyTokenForFetchDeepLinkingContentItems() {
-        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, "");
         assertNull(harmonyService.fetchDeepLinkingContentItems(SAMPLE_ROOT_OUTCOME_GUID, SAMPLE_ID_TOKEN, false, null));
     }
 
@@ -343,7 +287,6 @@ public class HarmonyServiceTest {
 
         assertNotNull(deepLinkingContentItemsList);
         HttpEntity<HarmonyFetchDeepLinksBody> httpEntity = httpEntityCaptor.getValue();
-        assertEquals("Bearer " + MOCK_HARMONY_JWT, Objects.requireNonNull(httpEntity.getHeaders().get("Authorization")).get(0));
         assertEquals(body, httpEntity.getBody());
         assertEquals(2, deepLinkingContentItemsList.size());
         assertTrue(deepLinkingContentItemsList.contains(deepLinkingContentItemDTO1));
@@ -354,7 +297,6 @@ public class HarmonyServiceTest {
     @Test
     public void testGoodResponseForFetchDeepLinkingContentItemsForReturningUser() {
         ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, MOCK_SERVER_URL);
-        ReflectionTestUtils.setField(harmonyService, HARMONY_JWT, MOCK_HARMONY_JWT);
 
         HarmonyContentItemDTO deepLinkingContentItemDTO1 = new HarmonyContentItemDTO();
         deepLinkingContentItemDTO1.setTitle("Reading 1");
@@ -380,7 +322,6 @@ public class HarmonyServiceTest {
         verify(restTemplate).exchange(eq(deepLinkingUrl), eq(HttpMethod.POST), httpEntityCaptor.capture(), eq(HarmonyContentItemDTO[].class));
         assertNotNull(deepLinkingContentItemsList);
         HttpEntity<HarmonyFetchDeepLinksBody> httpEntity = httpEntityCaptor.getValue();
-        assertEquals("Bearer " + MOCK_HARMONY_JWT, Objects.requireNonNull(httpEntity.getHeaders().get("Authorization")).get(0));
         assertEquals(body, httpEntity.getBody());
         assertEquals(2, deepLinkingContentItemsList.size());
         assertTrue(deepLinkingContentItemsList.contains(deepLinkingContentItemDTO1));
@@ -470,7 +411,6 @@ public class HarmonyServiceTest {
 
             verify(restTemplate).exchange(eq(MOCK_SERVER_LINEITEMS_URL), eq(HttpMethod.POST), httpEntityArgumentCaptor.capture(), eq(String.class));
             HttpEntity<String> entity = httpEntityArgumentCaptor.getValue();
-            assertEquals("Bearer " + MOCK_HARMONY_JWT, Objects.requireNonNull(entity.getHeaders().get("Authorization")).get(0));
             assertEquals(MediaType.APPLICATION_JSON, entity.getHeaders().getContentType());
             assertEquals("{\"lineitems\":[{\"id\":\"https://lms.com/course/lineitem/1\",\"scoreMaximum\":\"100\",\"label\":\"Quiz 1\"}],\"id_token\":\"sample-id-token\"}", entity.getBody());
             assertEquals(HttpStatus.OK, response.getStatusCode());


### PR DESCRIPTION
## Description
Removed the harmony JWT since the id_token will be used for auth instead.

### Motivation and Context
This removes extraneous complexity from the code.

### Fixes
[DL3-65](https://lumenlearning.atlassian.net/browse/DL3-65)

## How Has This Been Tested?
The full deep linking flow will be tested in the dev-env once SP-199 is ready. It is not testable locally outside of the unit tests.

## Screenshots
N/A

---

## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
This must be deployed simultaneously with SP-199.

## New ENV variables
The `harmony.courses.jwt` variable has been removed.

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [ ] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
