### PR TITLE
DL3-84 Remove the Breadcrumbs when the Loading Screen is Displayed fo…

### DIFF
--- a/src/main/frontend/src/app/appSlice.js
+++ b/src/main/frontend/src/app/appSlice.js
@@ -11,6 +11,9 @@ export const appSlice = createSlice({
     setLoading: (state, action) => {
       state.loading = action.payload;
     },
+    setIsFetchingDeepLinks: (state, action) => {
+      state.isFetchingDeepLinks = action.payload;
+    },
     setCourseArray: (state, action) => {
       state.courseArray = state.filteredCourseArray = action.payload;
     },
@@ -68,6 +71,7 @@ export const {
   setErrorFetchingCourses,
   setCourseArray,
   setLoading,
+  setIsFetchingDeepLinks,
   toggleAllModules,
   updateMetadata
 } = appSlice.actions;
@@ -78,6 +82,7 @@ export const selectSelectedCourse = (state) => state.selectedCourse;
 export const selectCourseArray = (state) => state.filteredCourseArray;
 export const selectMetadata = (state) => state.metadata;
 export const selectLoading = (state) => state.loading;
+export const selectIsFetchingDeepLinks = (state) => state.isFetchingDeepLinks;
 export const selectErrorFetchingCourses = (state) => state.errorFetchingCourses;
 export const selectErrorAssociatingCourse = (state) => state.errorAssociatingCourse;
 export const selectSelectedModules = (state) => state.selectedModules;

--- a/src/main/frontend/src/features/CoursePreview.js
+++ b/src/main/frontend/src/features/CoursePreview.js
@@ -12,7 +12,8 @@ import {
   selectRootOutcomeGuid,
   selectSelectedModules,
   selectState,
-  selectTarget
+  selectTarget,
+  setIsFetchingDeepLinks
 } from '../app/appSlice';
 
 import { parseCourseCoverImage } from '../util/Utils.js';
@@ -78,6 +79,8 @@ function CoursePreview(props) {
 
       // Display the spinner when fetching the deep links.
       setFetchingDeepLinks(true);
+      // Notify other components that a deep linking request has been started.
+      dispatch(setIsFetchingDeepLinks(true));
 
       const contextAPIUrl = target.replace("/lti3", "/context");
 
@@ -129,6 +132,8 @@ function CoursePreview(props) {
 
         // Remove the spinner once the request has responded.
         setFetchingDeepLinks(false);
+        // Notify other components that the request has been completed.
+        dispatch(setIsFetchingDeepLinks(false));
       });
   }
 

--- a/src/main/frontend/src/features/LtiBreadcrumb.js
+++ b/src/main/frontend/src/features/LtiBreadcrumb.js
@@ -5,6 +5,7 @@ import {
   changeSelectedCourse,
   selectSelectedCourse,
   selectRootOutcomeGuid,
+  selectIsFetchingDeepLinks,
   toggleAllModules
 } from '../app/appSlice';
 // Component imports
@@ -15,6 +16,8 @@ function LtiBreadcrumb(props) {
   const dispatch = useDispatch();
   const selectedCourse = useSelector(selectSelectedCourse);
   const rootOutcomeGuid = useSelector(selectRootOutcomeGuid);
+  // When the links are being added to the course we should not display the breadcrumbs.
+  const isFetchingDeepLinks = useSelector(selectIsFetchingDeepLinks);
 
   // A returning user means a user that previously associated a course with the LMS course, exists a previous root_outcome_guid selection.
   // When a course has been paired with the LMS, do not display the breadcrumb so the user cannot go back and select a different course.
@@ -27,7 +30,7 @@ function LtiBreadcrumb(props) {
 
   return (
     <Breadcrumb role="navigation">
-      {!isReturningUser &&
+      { (!isFetchingDeepLinks && !isReturningUser ) &&
         <>
           <Breadcrumb.Item onClick={(e) => resetSelection()}>Lumen Learning</Breadcrumb.Item>
           <Breadcrumb.Item active={!selectedCourse} onClick={(e) => resetSelection()}>Add Course</Breadcrumb.Item>

--- a/src/main/frontend/src/index.js
+++ b/src/main/frontend/src/index.js
@@ -31,6 +31,7 @@ const initialState = {
   searchInputText: '',
   selectedCourse: null,
   loading: true,
+  isFetchingDeepLinks: false,
   errorFetchingCourses: false,
   errorAssociatingCourse: false,
   selectedModules: [],


### PR DESCRIPTION
…llowing Add Course/Add Content

<!--- Provide a general summary of your changes in the Title above, including your Jira ticket ID. -->

## Description
Hides the breadcrumbs when deep links are being added.

### Motivation and Context
When a user adds a course or adds content to a course, displays a loading page, and it should also hide the breadcrumbs to prevent user navigation.

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/DL3-84)

## How Has This Been Tested?
Tested locally simulating the scenario.

## Screenshots

![image](https://user-images.githubusercontent.com/8653754/189623597-8cec221d-82c6-44dc-82c4-5b83d85cb025.png)


---
<!-- The following section calls out any changes that will impact the deploy of this PR and/or need to be shared with the team post-deploy. It is not meant to be all-inclusive; if there are additional things to note here, make a heading and do so :) -->

## Database changes
<!-- Describe any database changes here. -->

## ⚠️ Deployment instructions ⚠️
<!-- Make note of any unique-to-this-PR deployment instructions here. -->

## New ENV variables
<!-- Document any new ENV variables added as part of this work -->

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the AC for this feature and my changes meet all requirements
- [X] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have requested a review from at least one other dev
