### PR TITLE
DL3-85 Modify the text on the bottom of the returning user Course Pre…

### DIFF
--- a/src/main/frontend/src/features/CoursePreview.js
+++ b/src/main/frontend/src/features/CoursePreview.js
@@ -60,6 +60,8 @@ function CoursePreview(props) {
   const [selectAllChecked, setSelectAllChecked] = useState(!isReturningUser);
   // If the course has been paired with a Lumen course we must display a different text for the button.
   const addButtonText = !isReturningUser ? 'Add Course' : 'Add Content';
+  const helpText = !isReturningUser ? 'Clicking Add Course will add the selected content for this Lumen course to your LMS' :
+                   'Clicking Add Content will add the selected content for this Lumen course to your LMS';
 
   // When the user clicks cancel it should reset the module and the course selection.
   const resetSelection = () => {
@@ -169,7 +171,7 @@ function CoursePreview(props) {
         <CourseTOC topics={props.course.table_of_contents} />
       </div>
       <div className="fixed-bottom course-footer d-flex flex-row">
-          <p className="action-info">Clicking Add Course will add all of the content for this Lumen course to your LMS</p>
+          <p className="action-info">{helpText}</p>
           <div className="ms-auto mx-3 d-flex d-row">
             {!isReturningUser && <Button variant="secondary" onClick={(e) => resetSelection()}>Cancel</Button>}
             <Button disabled={!hasSelectedModules} variant="primary" className="ms-1" onClick={(e) => addCourseToLMS()}>{addButtonText}</Button>


### PR DESCRIPTION
…view page

<!--- Provide a general summary of your changes in the Title above, including your Jira ticket ID. -->

## Description
Updates a text when is a returning user.

### Motivation and Context
When is a returning user, the button states 'Add Content' while the text states 'Add Course', text needs to be updated accordingly.

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/DL3-85)

## How Has This Been Tested?
Tested locally simulating both scenarios.

## Screenshots
![image](https://user-images.githubusercontent.com/8653754/189625036-76f0f71f-f3d1-4970-9597-2a2bae733b5d.png)

---
<!-- The following section calls out any changes that will impact the deploy of this PR and/or need to be shared with the team post-deploy. It is not meant to be all-inclusive; if there are additional things to note here, make a heading and do so :) -->

## Database changes
<!-- Describe any database changes here. -->

## ⚠️ Deployment instructions ⚠️
<!-- Make note of any unique-to-this-PR deployment instructions here. -->

## New ENV variables
<!-- Document any new ENV variables added as part of this work -->

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the AC for this feature and my changes meet all requirements
- [X] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have requested a review from at least one other dev
