### PR TITLE
DL3-82 Limit the use of the loading screen in the Content Selector an

### DIFF
--- a/src/main/frontend/src/App.js
+++ b/src/main/frontend/src/App.js
@@ -3,15 +3,13 @@ import { useSelector } from 'react-redux';
 
 // Store imports
 import {
-  selectSelectedCourse,
-  selectLoading
+  selectSelectedCourse
 } from './app/appSlice';
 
 // Components import
 import Container from 'react-bootstrap/Container';
 import CoursePreview from './features/CoursePreview';
 import CoursePicker from './features/CoursePicker';
-import LoadingPage from './features/LoadingPage';
 import LtiBreadcrumb from './features/LtiBreadcrumb';
 
 // Stylesheet imports
@@ -25,16 +23,12 @@ function App() {
   window.scrollTo(0, 0);
 
   const selectedCourse = useSelector(selectSelectedCourse);
-  const isLoading = useSelector(selectLoading);
 
   // Show the course picker by default
   let appContent = <CoursePicker />;
 
-  // Display a spinner when the app is loading data from the backend....
-  if (isLoading) {
-    return <LoadingPage />;
   // When a course has been selected display the course preview.
-  } else if (selectedCourse) {
+  if (selectedCourse) {
     appContent = <CoursePreview course={selectedCourse} />
   }
 

--- a/src/main/frontend/src/features/CoursePicker.js
+++ b/src/main/frontend/src/features/CoursePicker.js
@@ -1,6 +1,10 @@
 // Redux imports
 import { useSelector } from 'react-redux';
-import { selectErrorAssociatingCourse, selectErrorFetchingCourses } from '../app/appSlice';
+import {
+  selectErrorAssociatingCourse,
+  selectErrorFetchingCourses,
+  selectLoading
+} from '../app/appSlice';
 
 // Components import
 import Col from 'react-bootstrap/Col';
@@ -10,12 +14,18 @@ import ErrorAlert from './alerts/ErrorAlert';
 import Header from './Header';
 import Row from 'react-bootstrap/Row';
 import SearchInput from './controls/SearchInput';
+import Spinner from 'react-bootstrap/Spinner';
 
 function CoursePicker (props) {
 
   // useSelector gets the value present in the store, this value may change at a component level.
   const isErrorFetchingCourses = useSelector(selectErrorFetchingCourses);
   const isErrorAssociatingCourse = useSelector(selectErrorAssociatingCourse);
+  const isLoading = useSelector(selectLoading);
+
+  // Display a Spinner when courses are being loaded.
+  const loadingText = 'Loading courses, please wait...';
+  const loadingComponent = <div className="header"><Spinner animation="border" role="status"><span className="visually-hidden">{loadingText}</span></Spinner> {loadingText}</div>;
 
   // Display an error message when the courses cannot be fetched from Harmony.
   if (isErrorFetchingCourses) {
@@ -44,7 +54,7 @@ function CoursePicker (props) {
         </Row>
       </div>
       <>
-        <CourseGrid />
+        {!isLoading ? <CourseGrid /> : loadingComponent}
         <div className="paginator d-flex justify-content-center">
           <Row>
             <CoursePaginator />

--- a/src/main/frontend/src/features/CoursePreview.js
+++ b/src/main/frontend/src/features/CoursePreview.js
@@ -79,6 +79,9 @@ function CoursePreview(props) {
 
   const addCourseToLMS = () => {
 
+      // The window will never notice if the user is browsing in long contents or not, should always scroll to top when fetching items.
+      window.scrollTo(0, 0);
+
       // Display the spinner when fetching the deep links.
       setFetchingDeepLinks(true);
       // Notify other components that a deep linking request has been started.
@@ -98,7 +101,6 @@ function CoursePreview(props) {
       }
 
       // TODO: Handle error cases of blank/null values
-
       const bookPairingData = {
         "id_token": idToken,
         "root_outcome_guid": props.course.root_outcome_guid,
@@ -127,14 +129,9 @@ function CoursePreview(props) {
         form.submit();
       }).catch(reason => {
         setErrorAddingLinks(true);
-      }).finally( () => {
-
-        // The window will never notice if the user is browsing in long contents or not, should always scroll to top when navigating across courses.
-        window.scrollTo(0, 0);
-
-        // Remove the spinner once the request has responded.
+        // Remove the spinner once the request has responded with an error, otherwise the LMS will close the modal.
         setFetchingDeepLinks(false);
-        // Notify other components that the request has been completed.
+        // Notify other components that the request has been completed with an error.
         dispatch(setIsFetchingDeepLinks(false));
       });
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including your Jira ticket ID. -->

## Description
Only display the loading screen when a course or modules have been selected, when courses are being loaded display a simple spinner like the previous version.

### Motivation and Context
The loading screen should only be displayed when a course is being paired, not when courses are being loaded.

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/DL3-82)

## How Has This Been Tested?
Tested locally simulating the scenarios. Tested against D2L using the DEV environment.

## Screenshots

![image](https://user-images.githubusercontent.com/8653754/189636100-647dd035-a412-4b4f-849c-14eb900b867c.png)


---
<!-- The following section calls out any changes that will impact the deploy of this PR and/or need to be shared with the team post-deploy. It is not meant to be all-inclusive; if there are additional things to note here, make a heading and do so :) -->

## Database changes
<!-- Describe any database changes here. -->

## ⚠️ Deployment instructions ⚠️
<!-- Make note of any unique-to-this-PR deployment instructions here. -->

## New ENV variables
<!-- Document any new ENV variables added as part of this work -->

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the AC for this feature and my changes meet all requirements
- [X] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have requested a review from at least one other dev
