### PR TITLE
DL3-56 Display error message if LINEITEMs aren't successfully synced to Harmony

### DIFF
--- a/src/main/frontend/public/index.html
+++ b/src/main/frontend/public/index.html
@@ -19,7 +19,8 @@
           iss: '[[${iss}]]',
           context: '[[${context}]]',
           root_outcome_guid: '[[${root_outcome_guid}]]',
-          platform_family_code: '[[${platform_family_code}]]'
+          platform_family_code: '[[${platform_family_code}]]',
+          lti_lineitems_sync_error: '[[${lti_lineitems_sync_error}]]'
         };
         <!--/* We have to set an attribute to the root element so the APP can use the values of the LTI launch data. */-->
         document.getElementById('root').setAttribute('lti-launch-data', JSON.stringify(ltiLaunchData));

--- a/src/main/frontend/src/App.js
+++ b/src/main/frontend/src/App.js
@@ -3,13 +3,15 @@ import { useSelector } from 'react-redux';
 
 // Store imports
 import {
-  selectSelectedCourse
+  selectSelectedCourse,
+  selectLtiLineItemsSyncError
 } from './app/appSlice';
 
 // Components import
 import Container from 'react-bootstrap/Container';
 import CoursePreview from './features/CoursePreview';
 import CoursePicker from './features/CoursePicker';
+import ErrorAlert from './features/alerts/ErrorAlert';
 import LtiBreadcrumb from './features/LtiBreadcrumb';
 
 // Stylesheet imports
@@ -23,6 +25,15 @@ function App() {
   window.scrollTo(0, 0);
 
   const selectedCourse = useSelector(selectSelectedCourse);
+  const errorSyncingLineItems = useSelector(selectLtiLineItemsSyncError);
+
+  // This error comes from the backend when there's an issue syncing line items, we must display an error when this happens. it's sent as string.
+  if (errorSyncingLineItems === "true") {
+    const syncingErrorMessage = `Oops, something went wrong and we couldn't load your content. Please try again. If the issue persists, please contact Lumen Support.`;
+    return <Container className="App" fluid role="main">
+             <div className="mt-3"><ErrorAlert message={syncingErrorMessage} /></div>
+           </Container>;
+  }
 
   // Show the course picker by default
   let appContent = <CoursePicker />;

--- a/src/main/frontend/src/app/appSlice.js
+++ b/src/main/frontend/src/app/appSlice.js
@@ -95,6 +95,7 @@ export const selectIdToken = (state) => state.id_token;
 export const selectState = (state) => state.state;
 export const selectTarget = (state) => state.target;
 export const selectRootOutcomeGuid = (state) => state.root_outcome_guid;
+export const selectLtiLineItemsSyncError = (state) => state.lti_lineitems_sync_error;
 
 // This function fetches the courses from the backend, it should be invoked when loading the application.
 export const fetchCourses = (page) => (dispatch, getState) => {

--- a/src/main/frontend/src/index.js
+++ b/src/main/frontend/src/index.js
@@ -44,7 +44,8 @@ const initialState = {
   state: ltiLaunchData.state,
   target: ltiLaunchData.target,
   root_outcome_guid: isValidRootOutcomeGuid(ltiLaunchData.root_outcome_guid) ? ltiLaunchData.root_outcome_guid : null,
-  platform_family_code: ltiLaunchData.platform_family_code
+  platform_family_code: ltiLaunchData.platform_family_code,
+  lti_lineitems_sync_error: ltiLaunchData.lti_lineitems_sync_error,
 };
 
 // Creates the store and preloads the initial state of the store.

--- a/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
@@ -151,13 +151,19 @@ public class LTI3Controller {
                             } else {
                                 log.error("Harmony lineitems API did not return root_outcome_guid");
                                 model.addAttribute("Error", "Harmony Lineitems API returned " + harmonyLineitemsResponse.getStatusCode() + "\n" + harmonyLineitemsResponse.getBody());
-                                return "lti3Error";
+                                // When there's an error syncing LineItems the frontend will display a specific error.
+                                model.addAttribute(TextConstants.LTI_LINEITEMS_SYNC_ERROR, true);
+                                // This redirects to the REACT UI which is a secondary set of templates.
+                                return TextConstants.REACT_UI_TEMPLATE;
                             }
                         } else {
                             log.error("Harmony Lineitems API returned {}", harmonyLineitemsResponse.getStatusCode());
                             log.error(String.valueOf(harmonyLineitemsResponse.getBody()));
                             model.addAttribute("Error", "Harmony Lineitems API returned " + harmonyLineitemsResponse.getStatusCode() + "\n" + harmonyLineitemsResponse.getBody());
-                            return "lti3Error";
+                            // When there's an error syncing LineItems the frontend will display a specific error.
+                            model.addAttribute(TextConstants.LTI_LINEITEMS_SYNC_ERROR, true);
+                            // This redirects to the REACT UI which is a secondary set of templates.
+                            return TextConstants.REACT_UI_TEMPLATE;
                         }
                     } else {
                         log.info("No lineitems found in the LMS for iss {}, client_id {}, deployment_id {}, LMS context_id {}, and lineitems URL {}.",

--- a/src/main/java/net/unicon/lti/utils/TextConstants.java
+++ b/src/main/java/net/unicon/lti/utils/TextConstants.java
@@ -40,5 +40,6 @@ public class TextConstants {
     public static final String ALL_LINEITEMS_TYPE = "application/vnd.ims.lis.v2.lineitemcontainer+json";
     public static final String RESULTS_TYPE = "application/vnd.ims.lis.v2.resultcontainer+json";
     public static final String REACT_UI_TEMPLATE = "index";
+    public static final String LTI_LINEITEMS_SYNC_ERROR = "lti_lineitems_sync_error";
 
 }

--- a/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
@@ -420,7 +420,8 @@ public class LTI3ControllerTest {
 
             assertEquals("Harmony Lineitems API returned 500 INTERNAL_SERVER_ERROR\nnull", model.getAttribute("Error"));
 
-            assertEquals("lti3Error", response);
+            assertEquals(true, model.getAttribute(TextConstants.LTI_LINEITEMS_SYNC_ERROR));
+            assertEquals(TextConstants.REACT_UI_TEMPLATE, response);
 
         } catch (ConnectionException | JsonProcessingException | DataServiceException e) {
             fail(UNIT_TEST_EXCEPTION_TEXT);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including your Jira ticket ID. -->

## Description
When there's an error syncing line items the frontend must display an error.

### Motivation and Context
Provides an error message when there's an error syncing line items

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/DL3-56)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to see how your change affects other areas of the code, etc. -->

Tested locally simulating the scenarios and tested against D2L.

## Screenshots
![DL3-56](https://user-images.githubusercontent.com/8653754/189908430-f72de321-5301-4d28-b97a-da2b5b796ef9.jpg)
![DL3-56](https://user-images.githubusercontent.com/8653754/189908433-8622ed61-093c-4be5-b049-615566449021.gif)



---
<!-- The following section calls out any changes that will impact the deploy of this PR and/or need to be shared with the team post-deploy. It is not meant to be all-inclusive; if there are additional things to note here, make a heading and do so :) -->

## Database changes
<!-- Describe any database changes here. -->

## ⚠️ Deployment instructions ⚠️
<!-- Make note of any unique-to-this-PR deployment instructions here. -->

## New ENV variables
<!-- Document any new ENV variables added as part of this work -->

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the AC for this feature and my changes meet all requirements
- [X] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have requested a review from at least one other dev
