### PR TITLE
DL3-92 fix resttemplate error handling

### DIFF
--- a/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
@@ -138,8 +138,8 @@ public class LTI3Controller {
                         // if no exceptions were thrown and root_outcome_guid received, set lineitems synced to true for the context
                         if (harmonyLineitemsResponse != null && harmonyLineitemsResponse.getStatusCode().is2xxSuccessful()) {
                             Map<String, String> rogMap = harmonyLineitemsResponse.getBody();
-                            String rootOutcomeGuid = rogMap.get("root_outcome_guid");
-                            if (StringUtils.isNotBlank(rootOutcomeGuid)) {
+                            if (rogMap != null && StringUtils.isNotBlank(rogMap.get("root_outcome_guid"))) {
+                                String rootOutcomeGuid = rogMap.get("root_outcome_guid");
                                 log.info("{} lineitems have been synced to Harmony successfully for iss {}, client_id {}, deployment_id {}, and LMS context_id {}. We received root_outcome_guid {} from Harmony.",
                                         lineItems.getLineItemList().size(), lti3Request.getIss(), lti3Request.getAud(), lti3Request.getLtiDeploymentId(), ltiContext.getContextKey(), rootOutcomeGuid);
                                 if (StringUtils.isBlank(ltiContext.getRootOutcomeGuid())) {
@@ -211,14 +211,20 @@ public class LTI3Controller {
             log.error("Invalid Signature: {}", e.getMessage() + "\n" + Arrays.toString(e.getStackTrace()));
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid signature");
         } catch (ConnectionException e) {
-            log.error("Could not fetch lineitems to sync with harmony: {}", e.getMessage() + "\n" + Arrays.toString(e.getStackTrace()));
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Could not fetch lineitems to sync with Harmony");
+            log.error("Could not fetch lineitems from LMS to sync with harmony: {}", e.getMessage() + "\n" + Arrays.toString(e.getStackTrace()));
+            // When there's an error syncing LineItems the frontend will display a specific error.
+            model.addAttribute(TextConstants.LTI_LINEITEMS_SYNC_ERROR, true);
+            // This redirects to the REACT UI which is a secondary set of templates.
+            return TextConstants.REACT_UI_TEMPLATE;
         } catch (GeneralSecurityException e) {
             log.error("Error: {}", e.getMessage() + "\n" + Arrays.toString(e.getStackTrace()));
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Error");
         } catch (JsonProcessingException | DataServiceException e) {
             log.error("HarmonyService could not receive lineitems: {}", e.getMessage() + "\n" + Arrays.toString(e.getStackTrace()));
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Harmony could not receive lineitems");
+            // When there's an error syncing LineItems the frontend will display a specific error.
+            model.addAttribute(TextConstants.LTI_LINEITEMS_SYNC_ERROR, true);
+            // This redirects to the REACT UI which is a secondary set of templates.
+            return TextConstants.REACT_UI_TEMPLATE;
         } catch (Exception e) {
             log.error("Error: {}", e.getMessage() + "\n" + Arrays.toString(e.getStackTrace()));
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage() + "\n Stack Trace: " + Arrays.toString(e.getStackTrace()));

--- a/src/main/java/net/unicon/lti/exceptions/helper/MiddlewareErrorHandler.java
+++ b/src/main/java/net/unicon/lti/exceptions/helper/MiddlewareErrorHandler.java
@@ -1,0 +1,11 @@
+package net.unicon.lti.exceptions.helper;
+
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+
+public class MiddlewareErrorHandler extends DefaultResponseErrorHandler {
+    @Override
+    public boolean hasError(ClientHttpResponse response) {
+        return false; // Errors thrown during REST calls (e.g. 4xx or 5xx statuses) will be handled by the middleware, not by Spring
+    }
+}

--- a/src/main/java/net/unicon/lti/utils/RestUtils.java
+++ b/src/main/java/net/unicon/lti/utils/RestUtils.java
@@ -1,5 +1,6 @@
 package net.unicon.lti.utils;
 
+import net.unicon.lti.exceptions.helper.MiddlewareErrorHandler;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.springframework.http.HttpMethod;
@@ -11,7 +12,9 @@ import java.net.URI;
 public class RestUtils {
 
     public static RestTemplate createRestTemplate() {
-        return new RestTemplate(new CustomHttpComponentsClientHttpRequestFactory());
+        RestTemplate restTemplate = new RestTemplate(new CustomHttpComponentsClientHttpRequestFactory());
+        restTemplate.setErrorHandler(new MiddlewareErrorHandler());
+        return restTemplate;
     }
 
     private static final class CustomHttpComponentsClientHttpRequestFactory extends HttpComponentsClientHttpRequestFactory {

--- a/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
@@ -45,6 +45,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -355,20 +356,18 @@ public class LTI3ControllerTest {
         try {
             when(advantageAGSService.getLineItems(eq(platformDeployment), eq(SAMPLE_LINEITEMS_URL))).thenThrow(new ConnectionException("Exception fetching lineitems"));
 
-            ResponseStatusException exception = Assertions.assertThrows(
-                    ResponseStatusException.class,
-                    () -> {lti3Controller.lti3(req, res, model);}
-            );
+            String response = lti3Controller.lti3(req, res, model);
 
             Mockito.verify(ltijwtService).validateState(VALID_STATE);
-            assertEquals(exception.getStatus(), HttpStatus.BAD_REQUEST);
-            assertTrue(Objects.requireNonNull(exception.getReason()).contains("Could not fetch lineitems to sync with Harmony"));
 
             // validate lineitems not synced
             Mockito.verify(ltiDataService).getDemoMode();
             Mockito.verify(advantageAGSService).getLineItems(eq(platformDeployment), eq(SAMPLE_LINEITEMS_URL));
             Mockito.verify(harmonyService, never()).postLineitemsToHarmony(any(LineItems.class), anyString());
             Mockito.verify(ltiContextRepository, never()).save(eq(ltiContext));
+
+            assertEquals(true, model.getAttribute(TextConstants.LTI_LINEITEMS_SYNC_ERROR));
+            assertEquals(TextConstants.REACT_UI_TEMPLATE, response);
         } catch (ConnectionException | JsonProcessingException | DataServiceException e) {
             fail(UNIT_TEST_EXCEPTION_TEXT);
         }
@@ -377,7 +376,6 @@ public class LTI3ControllerTest {
     @Test
     public void testNoErrorZeroLineitemsFetchedFromLMS() {
         try {
-            LineItems sampleLineItems = new LineItems();
             when(advantageAGSService.getLineItems(eq(platformDeployment), eq(SAMPLE_LINEITEMS_URL))).thenReturn(new LineItems());
 
             String response = lti3Controller.lti3(req, res, model);
@@ -397,6 +395,32 @@ public class LTI3ControllerTest {
             Jws<Claims> finalClaims = Jwts.parser().setSigningKey(kp.getPublic()).parseClaimsJws(finalIdToken);
             assertNotNull(finalClaims);
             assertEquals(response, "lti3Redirect");
+        } catch (ConnectionException | JsonProcessingException | DataServiceException e) {
+            fail(UNIT_TEST_EXCEPTION_TEXT);
+        }
+    }
+
+    @Test
+    public void testErrorNoRootOutcomeGuidSendingLineitemsToHarmony() {
+        try {
+            ResponseEntity<Map> harmonyResponse = new ResponseEntity<>(new HashMap(), HttpStatus.OK);
+            when(harmonyService.postLineitemsToHarmony(any(LineItems.class), anyString())).thenReturn(harmonyResponse);
+
+            String response = lti3Controller.lti3(req, res, model);
+
+            Mockito.verify(ltijwtService).validateState(VALID_STATE);
+
+            // validate lineitems synced
+            Mockito.verify(ltiDataService).getDemoMode();
+            Mockito.verify(advantageAGSService).getLineItems(eq(platformDeployment), eq(SAMPLE_LINEITEMS_URL));
+            Mockito.verify(harmonyService).postLineitemsToHarmony(any(LineItems.class), middlewareIdTokenCaptor.capture());
+            Mockito.verify(ltiContextRepository, never()).save(eq(ltiContext));
+
+            assertEquals("Harmony Lineitems API returned 200 OK\n{}", model.getAttribute("Error"));
+
+            assertEquals(true, model.getAttribute(TextConstants.LTI_LINEITEMS_SYNC_ERROR));
+            assertEquals(TextConstants.REACT_UI_TEMPLATE, response);
+
         } catch (ConnectionException | JsonProcessingException | DataServiceException e) {
             fail(UNIT_TEST_EXCEPTION_TEXT);
         }


### PR DESCRIPTION
## Description
Bypassed Spring's default error handling so that the middleware's error handling would run.

### Motivation and Context
This ensures that the error screens developed in DL3-56 appear when Valkyrie returns non-2xx response statuses or when Valkyrie doesn't return a response body when attempting to sync lineitems.

### Fixes
[DL3-92](https://lumenlearning.atlassian.net/browse/DL3-92)

## How Has This Been Tested?
1. As a prerequisite, I ensure that the tool was registered with the LMS and added to a course in the LMS and that links had been inserted from the tool to the LMS.
2. I commented out the mock Valkyrie lineitems endpoint to mimic Valkyrie returning a 404 when attempting to sync lineitems and redeployed my local environment.
3. I clicked on one of the links that had been inserted into my LMS course via deep linking and ensured that the error page displayed and that there were no extraneous errors in the logs.
4. I attempted to trigger the returning user flow by reopening the Deep Linking menu and ensured that the error page displayed and that there were no extraneous errors in the logs.
5. I uncommented out the mock Valkyrie lineitems endpoint and instead set it to return `HttpStatus.INTERNAL_SERVER_ERROR` to mimic Valkyrie returning a 500 error when attempting to sync lineitems and redeployed my local environment.
6. I repeated steps 3-4.
7. I reset the mock Valkyrie lineitems endpoint back to returning a `HttpStatus.OK` and commented out the lineitems JSON replacing it with just an empty string to mimic no root_outcome_guid being returned. Then I redeployed my local environment.
8. I repeated steps 3-4.
9. I reset the mock Valkyrie lineitems endpoint back to appropriately returning a root_outcome_guid and redeployed my local environment.
10. I repeated step 3 and ensured that I was able to get to my mock study plan.

## Screenshots
N/A

---
## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
N/A

## New ENV variables
N/A

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [ ] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
