### PR TITLE
WAYM-1626: Update LTI_MIDDLEWARE_NAME and Target URI values for Waymaker Dynamic Registration

### DIFF
--- a/src/main/java/net/unicon/lti/service/lti/impl/RegistrationServiceImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/RegistrationServiceImpl.java
@@ -64,6 +64,9 @@ public class RegistrationServiceImpl implements RegistrationService {
     @Value("${application.deep.linking.menu.label}")
     private String deepLinkingMenuLabel;
 
+    @Value("${lti13.enableDeepLinking}")
+    private boolean enableDeepLinking;
+
     @Autowired
     private ExceptionMessageGenerator exceptionMessageGenerator;
 
@@ -148,9 +151,7 @@ public class RegistrationServiceImpl implements RegistrationService {
         toolConfigurationDTO.setDescription(description);
         List<ToolMessagesSupportedDTO> messages = new ArrayList<>();
 
-        // Staging: https://goldilocks.ludev.team 
-        // Production: https://goldilocks.lumenlearning.com 
-        if (!domainUrl.contains("goldilocks")) { // Goldilocks shouldn't support deep linking - although this is non-critical and will not break dynamic registration if deep linking IS set for Goldilocks
+        if (enableDeepLinking) { // Goldilocks shouldn't support deep linking - although this is non-critical and will not break dynamic registration if deep linking IS set for Goldilocks
             // Indicate Deep Linking support
             ToolMessagesSupportedDTO message1 = new ToolMessagesSupportedDTO();
             message1.setType("LtiDeepLinkingRequest");

--- a/src/main/java/net/unicon/lti/service/lti/impl/RegistrationServiceImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/RegistrationServiceImpl.java
@@ -142,20 +142,22 @@ public class RegistrationServiceImpl implements RegistrationService {
         //OPTIONAL -->setSecondary_domains --> Collections.singletonList
         //OPTIONAL -->setDeployment_id
 
-        toolConfigurationDTO.setTarget_link_uri(domainUrl);
+        toolConfigurationDTO.setTarget_link_uri(localUrl + TextConstants.LTI3_SUFFIX);
 
         //OPTIONAL -->setCustom_parameters --> Map
         toolConfigurationDTO.setDescription(description);
         List<ToolMessagesSupportedDTO> messages = new ArrayList<>();
 
-        // Indicate Deep Linking support
-        ToolMessagesSupportedDTO message1 = new ToolMessagesSupportedDTO();
-        message1.setType("LtiDeepLinkingRequest");
-        message1.setTarget_link_uri(localUrl + TextConstants.LTI3_SUFFIX);
-        message1.setLabel(deepLinkingMenuLabel);
-//        OPTIONAL: --> message1 --> setIcon_uri
-//        OPTIONAL: --> message1 --> setCustom_parameters
-        messages.add(message1);
+        if (!domainUrl.contains("goldilocks")) {
+            // Indicate Deep Linking support
+            ToolMessagesSupportedDTO message1 = new ToolMessagesSupportedDTO();
+            message1.setType("LtiDeepLinkingRequest");
+            message1.setTarget_link_uri(localUrl + TextConstants.LTI3_SUFFIX);
+            message1.setLabel(deepLinkingMenuLabel);
+            //OPTIONAL: --> message1 --> setIcon_uri
+            //OPTIONAL: --> message1 --> setCustom_parameters
+            messages.add(message1);
+        }
 
         ToolMessagesSupportedDTO message2 = new ToolMessagesSupportedDTO();
         message2.setType("LtiResourceLinkRequest");

--- a/src/main/java/net/unicon/lti/service/lti/impl/RegistrationServiceImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/RegistrationServiceImpl.java
@@ -148,7 +148,9 @@ public class RegistrationServiceImpl implements RegistrationService {
         toolConfigurationDTO.setDescription(description);
         List<ToolMessagesSupportedDTO> messages = new ArrayList<>();
 
-        if (!domainUrl.contains("goldilocks")) {
+        // Staging: https://goldilocks.ludev.team 
+        // Production: https://goldilocks.lumenlearning.com 
+        if (!domainUrl.contains("goldilocks")) { // Goldilocks shouldn't support deep linking - although this is non-critical and will not break dynamic registration if deep linking IS set for Goldilocks
             // Indicate Deep Linking support
             ToolMessagesSupportedDTO message1 = new ToolMessagesSupportedDTO();
             message1.setType("LtiDeepLinkingRequest");

--- a/src/test/java/net/unicon/lti/service/lti/test/RegistrationServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/lti/test/RegistrationServiceTest.java
@@ -191,7 +191,7 @@ public class RegistrationServiceTest {
     }
 
     @Test
-    public void testGenerateToolConfiguration() {
+    public void testGenerateToolConfigurationGoldilocks() {
         ReflectionTestUtils.setField(registrationService, DOMAIN_URL, "https://fake-goldilocks.com");
         PlatformRegistrationDTO platformRegistration = new PlatformRegistrationDTO();
         List<String> customClaims = List.of("custom-claim-1", "custom-claim-2");

--- a/src/test/java/net/unicon/lti/service/lti/test/RegistrationServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/lti/test/RegistrationServiceTest.java
@@ -169,7 +169,7 @@ public class RegistrationServiceTest {
         assertEquals(SAMPLE_LOCAL_URL + "/jwks/jwk", toolRegistration.getJwks_uri());
         ToolConfigurationDTO toolConfiguration = toolRegistration.getToolConfiguration();
         assertEquals(SAMPLE_DOMAIN_URL, toolConfiguration.getDomain());
-        assertEquals(SAMPLE_DOMAIN_URL, toolConfiguration.getTarget_link_uri());
+        assertEquals(SAMPLE_LOCAL_URL + LTI3_SUFFIX, toolConfiguration.getTarget_link_uri());
         assertEquals(SAMPLE_DESCRIPTION, toolConfiguration.getDescription());
 
         // Validate tool supports Deep Linking

--- a/src/test/java/net/unicon/lti/service/lti/test/RegistrationServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/lti/test/RegistrationServiceTest.java
@@ -214,7 +214,7 @@ public class RegistrationServiceTest {
         assertEquals(SAMPLE_CLIENT_NAME, toolRegistration.getClient_name());
         assertEquals(SAMPLE_LOCAL_URL + "/jwks/jwk", toolRegistration.getJwks_uri());
         ToolConfigurationDTO toolConfiguration = toolRegistration.getToolConfiguration();
-        assertEquals(SAMPLE_DOMAIN_URL, toolConfiguration.getDomain());
+        assertEquals("https://fake-goldilocks.com", toolConfiguration.getDomain());
         assertEquals(SAMPLE_LOCAL_URL + LTI3_SUFFIX, toolConfiguration.getTarget_link_uri());
         assertEquals(SAMPLE_DESCRIPTION, toolConfiguration.getDescription());
 

--- a/src/test/java/net/unicon/lti/service/lti/test/RegistrationServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/lti/test/RegistrationServiceTest.java
@@ -57,6 +57,8 @@ public class RegistrationServiceTest {
     private static final String SAMPLE_DESCRIPTION = "LTI 1.3 Tool Description";
     private static final String DEEP_LINKING_MENU_LABEL = "deepLinkingMenuLabel";
     private static final String SAMPLE_DEEP_LINKING_MENU_LABEL = "Tool Content Selector";
+    private static final String ENABLE_DEEP_LINKING = "enableDeepLinking";
+    private static final boolean SAMPLE_ENABLE_DEEP_LINKING = true;
 
     @InjectMocks
     private RegistrationService registrationService = new RegistrationServiceImpl();
@@ -79,6 +81,7 @@ public class RegistrationServiceTest {
         ReflectionTestUtils.setField(registrationService, CLIENT_NAME, SAMPLE_CLIENT_NAME);
         ReflectionTestUtils.setField(registrationService, DESCRIPTION, SAMPLE_DESCRIPTION);
         ReflectionTestUtils.setField(registrationService, DEEP_LINKING_MENU_LABEL, SAMPLE_DEEP_LINKING_MENU_LABEL);
+        ReflectionTestUtils.setField(registrationService, ENABLE_DEEP_LINKING, SAMPLE_ENABLE_DEEP_LINKING);
     }
 
     @AfterEach
@@ -192,7 +195,7 @@ public class RegistrationServiceTest {
 
     @Test
     public void testGenerateToolConfigurationGoldilocks() {
-        ReflectionTestUtils.setField(registrationService, DOMAIN_URL, "https://fake-goldilocks.com");
+        ReflectionTestUtils.setField(registrationService, ENABLE_DEEP_LINKING, !SAMPLE_ENABLE_DEEP_LINKING);
         PlatformRegistrationDTO platformRegistration = new PlatformRegistrationDTO();
         List<String> customClaims = List.of("custom-claim-1", "custom-claim-2");
         platformRegistration.setClaims_supported(customClaims);
@@ -214,11 +217,11 @@ public class RegistrationServiceTest {
         assertEquals(SAMPLE_CLIENT_NAME, toolRegistration.getClient_name());
         assertEquals(SAMPLE_LOCAL_URL + "/jwks/jwk", toolRegistration.getJwks_uri());
         ToolConfigurationDTO toolConfiguration = toolRegistration.getToolConfiguration();
-        assertEquals("https://fake-goldilocks.com", toolConfiguration.getDomain());
+        assertEquals(SAMPLE_DOMAIN_URL, toolConfiguration.getDomain());
         assertEquals(SAMPLE_LOCAL_URL + LTI3_SUFFIX, toolConfiguration.getTarget_link_uri());
         assertEquals(SAMPLE_DESCRIPTION, toolConfiguration.getDescription());
 
-        // Validate tool supports Deep Linking
+        // Validate message types supported
         List<ToolMessagesSupportedDTO> toolMessagesSupportedList = toolConfiguration.getMessages_supported();
 
         // Validate tool supports LTI Core SSO Standard Launch (aka LtiResourceLinkRequest)


### PR DESCRIPTION
## Description
- filter by domain such that the Valkyrie middleware enables Deep Linking but not Waymaker
- Adjust the target link uri such that it correctly points to the /lti route, not the domain
- Environment changes to staging: domain.url set to https://goldilocks.ludev.team and LTI_MIDDLEWARE_NAME set to Lumen Waymaker 1.3 Staging

### Motivation and Context
Fixes the target link uri for production and also fixes some config in staging environment as well. After conferring with Mary, the final say was that "Send Institution Role" is a non-critical setting that can't be configured dynamically via dynamic registration. Otherwise, the Assignment and Grade Services extension should be in place given how scopes are being assigned (accepting all supported scopes offered by LMS)

NOTE: production name has not been changed yet

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/WAYM-1626)

## How Has This Been Tested?
Adjusted existing test to fix target link uri and also create a new test to filter the messages (deep linking) when a goldilocks domain

## Screenshots
N/A

## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
N/A

## New ENV variables
domain.url was set explicitly in staging env, but it's nothing new to the properties

---

## Checklist
- [ ] I have reviewed the AC for this feature and my changes meet all requirements
- [ ] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
