### PR TITLE
DL3-93 Content Preview Page: Screen reader does not read sub-module c…

### DIFF
--- a/src/main/frontend/src/features/CourseTopic.js
+++ b/src/main/frontend/src/features/CourseTopic.js
@@ -15,7 +15,7 @@ function CourseTopic (props) {
   if (Array.isArray(props.topic.sub_topics) && props.topic.sub_topics.length) {
     courseSectionSubtopics = (<ul>
           {props.topic.sub_topics.map((item, index) => {
-            return <li key={index}>{item}</li>
+            return <li key={index} tabIndex="0">{item}</li>
           })}
         </ul>);
   }

--- a/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
@@ -211,7 +211,7 @@ public class LTI3Controller {
         } catch (ConnectionException e) {
             log.error("Could not fetch lineitems from LMS to sync with harmony: {}", e.getMessage() + "\n" + Arrays.toString(e.getStackTrace()));
             // When there's an error syncing LineItems the frontend will display a specific error.
-            model.addAttribute(TextConstants.LTI_LINEITEMS_SYNC_ERROR, true);
+            model.addAttribute(TextConstants.LTI_SYSTEM_ERROR, LtiSystemErrorEnum.LINEITEMS_SYNCING_ERROR.ordinal());
             // This redirects to the REACT UI which is a secondary set of templates.
             return TextConstants.REACT_UI_TEMPLATE;
         } catch (GeneralSecurityException e) {
@@ -220,7 +220,7 @@ public class LTI3Controller {
         } catch (JsonProcessingException | DataServiceException e) {
             log.error("HarmonyService could not receive lineitems: {}", e.getMessage() + "\n" + Arrays.toString(e.getStackTrace()));
             // When there's an error syncing LineItems the frontend will display a specific error.
-            model.addAttribute(TextConstants.LTI_LINEITEMS_SYNC_ERROR, true);
+            model.addAttribute(TextConstants.LTI_SYSTEM_ERROR, LtiSystemErrorEnum.LINEITEMS_SYNCING_ERROR.ordinal());
             // This redirects to the REACT UI which is a secondary set of templates.
             return TextConstants.REACT_UI_TEMPLATE;
         } catch (Exception e) {

--- a/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
+++ b/src/test/java/net/unicon/lti/controller/lti/LTI3ControllerTest.java
@@ -367,7 +367,7 @@ public class LTI3ControllerTest {
             Mockito.verify(harmonyService, never()).postLineitemsToHarmony(any(LineItems.class), anyString());
             Mockito.verify(ltiContextRepository, never()).save(eq(ltiContext));
 
-            assertEquals(true, model.getAttribute(TextConstants.LTI_LINEITEMS_SYNC_ERROR));
+            assertEquals(LtiSystemErrorEnum.LINEITEMS_SYNCING_ERROR.ordinal(), model.getAttribute(TextConstants.LTI_SYSTEM_ERROR));
             assertEquals(TextConstants.REACT_UI_TEMPLATE, response);
         } catch (ConnectionException | JsonProcessingException | DataServiceException e) {
             fail(UNIT_TEST_EXCEPTION_TEXT);
@@ -417,9 +417,7 @@ public class LTI3ControllerTest {
             Mockito.verify(harmonyService).postLineitemsToHarmony(any(LineItems.class), middlewareIdTokenCaptor.capture());
             Mockito.verify(ltiContextRepository, never()).save(eq(ltiContext));
 
-            assertEquals("Harmony Lineitems API returned 200 OK\n{}", model.getAttribute("Error"));
-
-            assertEquals(true, model.getAttribute(TextConstants.LTI_LINEITEMS_SYNC_ERROR));
+            assertEquals(LtiSystemErrorEnum.LINEITEMS_SYNCING_ERROR.ordinal(), model.getAttribute(TextConstants.LTI_SYSTEM_ERROR));
             assertEquals(TextConstants.REACT_UI_TEMPLATE, response);
 
         } catch (ConnectionException | JsonProcessingException | DataServiceException e) {


### PR DESCRIPTION
…ontent aloud

<!--- Provide a general summary of your changes in the Title above, including your Jira ticket ID. -->

## Description
Makes the topics of the table of contents navigable through the keyboard so screen readers like JAWS or NVDA reads them loud.

### Motivation and Context
Fixes an accessibility issue.

It also contains a fix for an unintentional problem introduced in DL3-92 #83 

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/DL3-93)

## How Has This Been Tested?
Tested locally and using D2L through dev-env, using NVDA as screen reader.

## Screenshots
![image](https://user-images.githubusercontent.com/8653754/190430698-c6bceeda-5b29-4969-bb3d-159a4640475e.png)


---
<!-- The following section calls out any changes that will impact the deploy of this PR and/or need to be shared with the team post-deploy. It is not meant to be all-inclusive; if there are additional things to note here, make a heading and do so :) -->

## Database changes
<!-- Describe any database changes here. -->

## ⚠️ Deployment instructions ⚠️
<!-- Make note of any unique-to-this-PR deployment instructions here. -->

## New ENV variables
<!-- Document any new ENV variables added as part of this work -->

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the AC for this feature and my changes meet all requirements
- [X] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have requested a review from at least one other dev
