### PR TITLE
DL3-90 fix duplicate registration error handling

### DIFF
--- a/src/main/java/net/unicon/lti/controller/lti/RegistrationController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/RegistrationController.java
@@ -60,7 +60,7 @@ import java.nio.charset.StandardCharsets;
 @RequestMapping("/registration")
 @ConditionalOnExpression("${lti13.enableDynamicRegistration}")
 public class RegistrationController {
-    private static final String D2L_DUPLICATE_REGISTRATION_ERROR = "400 Bad Request: \"{\"error\":\"invalid_registration_data\",\"error_description\":\"Name must be unique across the org\"}\"";
+    private static final String D2L_DUPLICATE_REGISTRATION_ERROR = "Name must be unique across the org";
 
     @Autowired
     PlatformDeploymentRepository platformDeploymentRepository;

--- a/src/main/java/net/unicon/lti/service/lti/impl/RegistrationServiceImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/RegistrationServiceImpl.java
@@ -101,10 +101,9 @@ public class RegistrationServiceImpl implements RegistrationService {
                 answer = registrationRequest.getBody();
                 log.info("Registration successfully confirmed! Platform's response to the Tool Registration DTO: {}", answer);
             } else {
+                log.error("Can't get confirmation of the registration");
                 log.error(registrationRequest.getBody());
-                String exceptionMsg = "Can't get confirmation of the registration";
-                log.error(exceptionMsg);
-                throw new ConnectionException(exceptionMsg);
+                throw new ConnectionException(registrationRequest.getBody());
             }
         } catch (Exception e) {
             StringBuilder exceptionMsg = new StringBuilder();


### PR DESCRIPTION
## Description
When I made the update to prioritize the middleware's error handling over Spring's method of throwing exceptions for any non-2xx response from REST calls, this broke the duplicate registration error handling because that was originally written expecting the non-2xx response to be included in the exception message instead of in the response body. This updates puts the response body with the appropriate message into the middleware's exception, allowing the correct error page to display in this case.

### Motivation and Context
When there is an attempt to create a duplicate instance of a dynamic registration in D2L, the user should see an error message that indicates that this is the problem.

### Fixes
[DL3-90](https://lumenlearning.atlassian.net/browse/DL3-90)

## How Has This Been Tested?
0. As a prerequisite, ensure that your tool has already been registered in D2L.
1. Navigate to the Dynamic Registration page in D2L.
2. Enter the middleware's dynamic registration URL and check the box to Configure Deployment.
3. Click the Register button.
4. Ensure that the error message displayed indicates that this registration already exists.

## Screenshots

---

## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
N/A

## New ENV variables
N/A

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [ ] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
