### PR TITLE
DL3-94 Updates to the course catalog and course preview loading screens

### DIFF
--- a/src/main/frontend/src/App.css
+++ b/src/main/frontend/src/App.css
@@ -175,3 +175,7 @@ li:not(:last-child) {
   max-width: 135px;
   padding: 10px;
 }
+
+.loading-courses {
+  min-height: 340px;
+}

--- a/src/main/frontend/src/App.js
+++ b/src/main/frontend/src/App.js
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 // Store imports
 import {
   selectSelectedCourse,
+  selectLoading,
   selectLtiSystemError
 } from './app/appSlice';
 
@@ -12,6 +13,7 @@ import Container from 'react-bootstrap/Container';
 import CoursePreview from './features/CoursePreview';
 import CoursePicker from './features/CoursePicker';
 import ErrorAlert from './features/alerts/ErrorAlert';
+import LoadingCoursesPage from './features/LoadingCoursesPage';
 import LtiBreadcrumb from './features/LtiBreadcrumb';
 
 // Stylesheet imports
@@ -29,6 +31,7 @@ function App() {
 
   const selectedCourse = useSelector(selectSelectedCourse);
   const ltiSystemErrorCode = useSelector(selectLtiSystemError);
+  const isLoading = useSelector(selectLoading);
 
   // When there's a system error from the backend we must inform the user and do not render any content.
   if (Number.isInteger(parseInt(ltiSystemErrorCode))) {
@@ -52,22 +55,18 @@ function App() {
            </Container>;
   }
 
-  // Show the course picker by default
-  let appContent = <CoursePicker />;
-
-  // When a course has been selected display the course preview.
-  if (selectedCourse) {
-    appContent = <CoursePreview course={selectedCourse} />
+  // When courses are being loaded display a loading page.
+  if (isLoading) {
+    return <LoadingCoursesPage />;
   }
 
-  return (
-    <>
-      <LtiBreadcrumb course={selectedCourse} />
-      <Container className="App" fluid role="main">
-        {appContent}
-      </Container>
-    </>
-  );
+  // When a course has been selected display the course preview.
+  return <>
+           <LtiBreadcrumb course={selectedCourse} />
+           <Container className="App" fluid role="main">
+             {selectedCourse ? <CoursePreview course={selectedCourse} /> : <CoursePicker />}
+           </Container>
+         </>;
 
 }
 

--- a/src/main/frontend/src/features/CoursePicker.js
+++ b/src/main/frontend/src/features/CoursePicker.js
@@ -2,8 +2,7 @@
 import { useSelector } from 'react-redux';
 import {
   selectErrorAssociatingCourse,
-  selectErrorFetchingCourses,
-  selectLoading
+  selectErrorFetchingCourses
 } from '../app/appSlice';
 
 // Components import
@@ -14,18 +13,12 @@ import ErrorAlert from './alerts/ErrorAlert';
 import Header from './Header';
 import Row from 'react-bootstrap/Row';
 import SearchInput from './controls/SearchInput';
-import Spinner from 'react-bootstrap/Spinner';
 
 function CoursePicker (props) {
 
   // useSelector gets the value present in the store, this value may change at a component level.
   const isErrorFetchingCourses = useSelector(selectErrorFetchingCourses);
   const isErrorAssociatingCourse = useSelector(selectErrorAssociatingCourse);
-  const isLoading = useSelector(selectLoading);
-
-  // Display a Spinner when courses are being loaded.
-  const loadingText = 'Loading courses, please wait...';
-  const loadingComponent = <div className="header"><Spinner animation="border" role="status"><span className="visually-hidden">{loadingText}</span></Spinner> {loadingText}</div>;
 
   // Display an error message when the courses cannot be fetched from Harmony.
   if (isErrorFetchingCourses) {
@@ -54,7 +47,7 @@ function CoursePicker (props) {
         </Row>
       </div>
       <>
-        {!isLoading ? <CourseGrid /> : loadingComponent}
+        <CourseGrid />
         <div className="paginator d-flex justify-content-center">
           <Row>
             <CoursePaginator />

--- a/src/main/frontend/src/features/LoadingCoursesPage.js
+++ b/src/main/frontend/src/features/LoadingCoursesPage.js
@@ -1,0 +1,22 @@
+// Component imports
+import Container from 'react-bootstrap/Container';
+import Spinner from 'react-bootstrap/Spinner';
+
+function LoadingCoursesPage (props) {
+
+  // Display a Spinner when courses are being loaded.
+  const loadingText = 'Loading content, please wait...';
+  const loadingComponent = <div className="loading-courses d-flex justify-content-center align-items-center m-4">
+                             <Spinner animation="border" role="status">
+                               <span className="visually-hidden">{loadingText}</span>
+                             </Spinner>
+                             {loadingText}
+                           </div>;
+
+  return <Container className="App" fluid role="main">
+           {loadingComponent}
+         </Container>;
+
+}
+
+export default LoadingCoursesPage;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including your Jira ticket ID. -->

## Description
When courses are loading do not display other components, just the spinner and the text.

### Motivation and Context
Makes the loading screen cleaner, removing other controls.

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/DL3-94)

## How Has This Been Tested?
Tested locally simulating the scenarios.

## Screenshots

![image](https://user-images.githubusercontent.com/8653754/190996070-e78947a3-d938-48e8-a431-8e2d648ed340.png)

---
<!-- The following section calls out any changes that will impact the deploy of this PR and/or need to be shared with the team post-deploy. It is not meant to be all-inclusive; if there are additional things to note here, make a heading and do so :) -->

## Database changes
<!-- Describe any database changes here. -->

## ⚠️ Deployment instructions ⚠️
<!-- Make note of any unique-to-this-PR deployment instructions here. -->

## New ENV variables
<!-- Document any new ENV variables added as part of this work -->

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the AC for this feature and my changes meet all requirements
- [X] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have requested a review from at least one other dev
