### PR TITLE
DL-96 [QA] Course Preview - Screen Reader reads course name twice in …

### DIFF
--- a/src/main/frontend/src/features/CourseCard.js
+++ b/src/main/frontend/src/features/CourseCard.js
@@ -11,6 +11,8 @@ function CourseCard (props) {
 
   // Some courses may not have a valid cover image, use a default instead
   const courseCoverUrl = parseCourseCoverImage(props.course.cover_img_url);
+  const courseTitle = props.course.book_title ? props.course.book_title : 'This course does not have a title.';
+  const courseCoverTitle = `The cover image for the ${courseTitle} course.`;
 
   const changeCourseSelection = () => {
     dispatch(changeSelectedCourse(props.course));
@@ -30,9 +32,9 @@ function CourseCard (props) {
       tabIndex="0"
       onKeyPress={(e) => checkPressedKey(e)}
       onClick={(e) => changeCourseSelection()} >
-        <Card.Img variant="top" src={courseCoverUrl} className="course-card-image" title={props.course.book_title}/>
+        <Card.Img variant="top" src={courseCoverUrl} className="course-card-image" title={courseCoverTitle} />
         <Card.Body>
-          <Card.Title className="course-card-title">{props.course.book_title ? props.course.book_title : 'This course does not have a title.'}</Card.Title>
+          <Card.Title className="course-card-title">{courseTitle}</Card.Title>
           <Card.Subtitle className="course-card-subtitle">Released: {props.course.release_date ? formatDate(props.course.release_date) : 'No release date has been provided.'}</Card.Subtitle>
         </Card.Body>
     </Card>

--- a/src/main/frontend/src/features/CoursePreview.js
+++ b/src/main/frontend/src/features/CoursePreview.js
@@ -48,6 +48,8 @@ function CoursePreview(props) {
 
   // Some courses may not have a valid cover image, use a default instead
   const courseCoverUrl = parseCourseCoverImage(props.course.cover_img_url, true);
+  const courseTitle = props.course.book_title ? props.course.book_title : 'This course does not have a title.';
+  const courseCoverTitle = `The cover image for the ${courseTitle} course.`;
   const dispatch = useDispatch();
 
   // In case there's an error adding the links, display an error message.
@@ -157,7 +159,7 @@ function CoursePreview(props) {
       <div className="course-info">
         <Row className="course-preview-info">
           <Col sm={2}>
-            <Image rounded fluid src={courseCoverUrl} title={props.course.book_title} />
+            <Image rounded fluid src={courseCoverUrl} title={courseCoverTitle} />
           </Col>
           <Col sm={10}>
             {(props.course.book_title || props.course.description) ?


### PR DESCRIPTION
…a row

<!--- Provide a general summary of your changes in the Title above, including your Jira ticket ID. -->

## Description
Updates the course cover image titles to improve the experience with screen readers.

### Motivation and Context
Right now the course cover image title is the course title, screen readers read the course title twice. This software change updates the course cover image title to improve the experience while using a screen reader.

### Fixes
[Jira ticket](https://lumenlearning.atlassian.net/browse/DL3-96)

## How Has This Been Tested?
Tested locally with multiple courses and covers.

## Screenshots

![image](https://user-images.githubusercontent.com/8653754/191690811-496449f2-417a-47c9-a6f7-3f203ac0acf1.png)


---
<!-- The following section calls out any changes that will impact the deploy of this PR and/or need to be shared with the team post-deploy. It is not meant to be all-inclusive; if there are additional things to note here, make a heading and do so :) -->

## Database changes
<!-- Describe any database changes here. -->

## ⚠️ Deployment instructions ⚠️
<!-- Make note of any unique-to-this-PR deployment instructions here. -->

## New ENV variables
<!-- Document any new ENV variables added as part of this work -->

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have reviewed the AC for this feature and my changes meet all requirements
- [X] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have requested a review from at least one other dev
