### PR TITLE
Dl3 97 do not sync lineitems if deep linking disabled

### DIFF
--- a/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
@@ -172,7 +172,7 @@ public class LTI3Controller {
                         log.info("Lineitems are already in sync and will not be synced again at this time");
                     }
                 } else {
-                    log.info("Deep linking is disabled.");
+                    log.info("Lineitems will not be synced because deep linking is disabled.");
                 }
 
                 // Setup data for the frontend

--- a/src/main/java/net/unicon/lti/service/harmony/HarmonyService.java
+++ b/src/main/java/net/unicon/lti/service/harmony/HarmonyService.java
@@ -131,6 +131,10 @@ public class HarmonyService {
     }
 
     public ResponseEntity<Map> postLineitemsToHarmony(LineItems lineItems, String idToken) throws JsonProcessingException, DataServiceException {
+        if (StringUtils.isBlank(harmonyCoursesApiUrl)) {
+            throw new DataServiceException("The Harmony API has not been configured, lineitems cannot be synced.");
+        }
+
         if (lineItems == null || lineItems.getLineItemList() == null || lineItems.getLineItemList().isEmpty()) {
             throw new DataServiceException("No lineitems to send to Harmony");
         }

--- a/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
+++ b/src/test/java/net/unicon/lti/service/harmony/HarmonyServiceTest.java
@@ -331,6 +331,26 @@ public class HarmonyServiceTest {
     }
 
     @Test
+    public void testPostLineitemsToHarmonyWithoutConfiguringHarmonyApi() {
+        ReflectionTestUtils.setField(harmonyService, HARMONY_COURSES_API_URL, "");
+        LineItems lineItems = new LineItems();
+        LineItem lineItem = new LineItem();
+        lineItem.setId("https://lms.com/course/lineitem/1");
+        lineItem.setScoreMaximum("100");
+        lineItem.setLabel("Quiz 1");
+        lineItems.setLineItemList(List.of(lineItem));
+
+        DataServiceException exception = Assertions.assertThrows(
+                DataServiceException.class,
+                () -> {
+                    harmonyService.postLineitemsToHarmony(lineItems, SAMPLE_ID_TOKEN);
+                }
+        );
+
+        assertEquals("The Harmony API has not been configured, lineitems cannot be synced.", exception.getMessage());
+    }
+
+    @Test
     public void testPostLineitemsToHarmonyWithNullLineitems() {
         DataServiceException exception = Assertions.assertThrows(
                 DataServiceException.class,


### PR DESCRIPTION
## Description
I updated the middleware to not try to sync the lineitems if deep linking is disabled. I also added INFO logging to indicate that this is happening (please let me know if this is overkill for logging - it will be very easy to remove).

### Motivation and Context
This ensures that there aren't errors when doing standard LTI core launches with deep linking disabled and no harmony API in place.

### Fixes
[DL3-97](https://lumenlearning.atlassian.net/browse/DL3-97)

## How Has This Been Tested?
1. Ensured that deep linking is enabled locally.
2. In a new course in the LMS that has access to my local tool, I went through the deep linking flow and inserted the links to my test course.
3. I clicked on one of the links I had inserted and ensured that the logs indicated that the lineitems syncing had taken place.
```
2022-09-22 16:18:12.479  INFO 18118 --- [-nio-443-exec-5] n.u.lti.controller.lti.LTI3Controller    : 23 lineitems have been synced to Harmony successfully for iss https://unicon.d2l-partners.brightspace.com, client_id 68ff69cc-7bb6-46c4-b899-31af213713e1, deployment_id b97f0815-d874-44c3-82d2-09beb0d66c05, and LMS context_id 6997. We received root_outcome_guid 357365c8-fd91-415b-8139-aa19779dabdd from Harmony.
```
4. I disabled Deep Linking in my local environment and redeployed.
5. I returned to the same course and clicked on one of the link and ensured that there were no errors in the logs and that there was no indication that lineitems had synced.
```
2022-09-22 16:20:56.912  INFO 18733 --- [-nio-443-exec-5] n.u.lti.controller.lti.LTI3Controller    : Lineitems will not be synced because deep linking is disabled.
```

## Screenshots
N/A

---
## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
N/A

## New ENV variables
N/A

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [ ] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev
