### PR TITLE
Bypass altdomains for local mock testing

### DIFF
--- a/src/main/java/net/unicon/lti/controller/lti/OIDCController.java
+++ b/src/main/java/net/unicon/lti/controller/lti/OIDCController.java
@@ -165,22 +165,24 @@ public class OIDCController {
         authRequestMap.put("nonce_hash", nonceHash);  //The hash value of the nonce
         authRequestMap.put("prompt", OIDC_NONE);  //Always this value, as specified in the standard.
         //Getting the right redirect url based on the target url.
-        String altDomain = DomainUtils.extractDomain(loginInitiationDTO.getTargetLinkUri());
         String altLocalUrl = ltiDataService.getLocalUrl();
-        log.debug("local url = " + ltiDataService.getLocalUrl() + "; domain = " + ltiDataService.getDomainUrl() + "; alt domain = " + loginInitiationDTO.getTargetLinkUri());
-        if (altDomain!=null){
-            altLocalUrl = DomainUtils.insertDomain(altDomain, altLocalUrl);
-        } else if (DomainUtils.isWildcardDomain(loginInitiationDTO.getTargetLinkUri(),altLocalUrl)) {
-            log.debug("Wildcard detected against local url");
-            String wildcardDomain = DomainUtils.extractWildcardDomain(loginInitiationDTO.getTargetLinkUri());
-            altLocalUrl = DomainUtils.insertWildcardDomain(wildcardDomain, altLocalUrl);
-        } else if (DomainUtils.isWildcardDomain(loginInitiationDTO.getTargetLinkUri(), ltiDataService.getDomainUrl())) {
-            log.debug("Wildcard detected against domain url");
-            String wildcardDomain = DomainUtils.extractWildcardDomain(loginInitiationDTO.getTargetLinkUri());
+        if (!ltiDataService.getEnableMockValkyrie()) {
+            String altDomain = DomainUtils.extractDomain(loginInitiationDTO.getTargetLinkUri());
+            log.debug("local url = " + ltiDataService.getLocalUrl() + "; domain = " + ltiDataService.getDomainUrl() + "; alt domain = " + loginInitiationDTO.getTargetLinkUri());
+            if (altDomain != null) {
+                altLocalUrl = DomainUtils.insertDomain(altDomain, altLocalUrl);
+            } else if (DomainUtils.isWildcardDomain(loginInitiationDTO.getTargetLinkUri(), altLocalUrl)) {
+                log.debug("Wildcard detected against local url");
+                String wildcardDomain = DomainUtils.extractWildcardDomain(loginInitiationDTO.getTargetLinkUri());
+                altLocalUrl = DomainUtils.insertWildcardDomain(wildcardDomain, altLocalUrl);
+            } else if (DomainUtils.isWildcardDomain(loginInitiationDTO.getTargetLinkUri(), ltiDataService.getDomainUrl())) {
+                log.debug("Wildcard detected against domain url");
+                String wildcardDomain = DomainUtils.extractWildcardDomain(loginInitiationDTO.getTargetLinkUri());
 //            altLocalUrl = DomainUtils.insertWildcardDomain(wildcardDomain, ltiDataService.getDomainUrl());
-            altLocalUrl = DomainUtils.insertWildcardDomain(wildcardDomain, altLocalUrl);
+                altLocalUrl = DomainUtils.insertWildcardDomain(wildcardDomain, altLocalUrl);
+            }
+            log.debug("altLocalUrl = " + altLocalUrl);
         }
-        log .debug("altLocalUrl = " + altLocalUrl);
         authRequestMap.put("redirect_uri", altLocalUrl + TextConstants.LTI3_SUFFIX);  // One of the valid redirect uris.
         authRequestMap.put("response_mode", OIDC_FORM_POST); //Always this value, as specified in the standard.
         authRequestMap.put("response_type", OIDC_ID_TOKEN); //Always this value, as specified in the standard.

--- a/src/main/java/net/unicon/lti/service/lti/LTIDataService.java
+++ b/src/main/java/net/unicon/lti/service/lti/LTIDataService.java
@@ -51,4 +51,8 @@ public interface LTIDataService {
     boolean getDeepLinkingEnabled();
 
     void setDeepLinkingEnabled(boolean deepLinkingEnabled);
+
+    boolean getEnableMockValkyrie();
+
+    void setEnableMockValkyrie(boolean enableMockValkyrie);
 }

--- a/src/main/java/net/unicon/lti/service/lti/impl/LTIDataServiceImpl.java
+++ b/src/main/java/net/unicon/lti/service/lti/impl/LTIDataServiceImpl.java
@@ -61,6 +61,9 @@ public class LTIDataServiceImpl implements LTIDataService {
     @Value("${lti13.enableDeepLinking}")
     private boolean deepLinkingEnabled;
 
+    @Value("${lti13.enableMockValkyrie}")
+    private boolean enableMockValkyrie;
+
 
     /**
      * Allows convenient access to the DAO repositories which manage the stored LTI data
@@ -404,5 +407,15 @@ public class LTIDataServiceImpl implements LTIDataService {
     @Override
     public void setDeepLinkingEnabled(boolean deepLinkingEnabled) {
         this.deepLinkingEnabled = deepLinkingEnabled;
+    }
+
+    @Override
+    public boolean getEnableMockValkyrie() {
+        return enableMockValkyrie;
+    }
+
+    @Override
+    public void setEnableMockValkyrie(boolean enableMockValkyrie) {
+        this.enableMockValkyrie = enableMockValkyrie;
     }
 }


### PR DESCRIPTION
## Description
If mock Valkyrie is enabled, then this is a local instance and alternate domains are not needed. Modifying the local url only breaks the flow.

### Motivation and Context
This allows the mock valkyrie features to continue to work for local testing.

### Fixes
N/A

## How Has This Been Tested?
This was tested using the typical Canvas deep linking flow. I also ensured that no unit tests were broken.

## Screenshots

---

## Database changes
N/A

## ⚠️ Deployment instructions ⚠️
N/A

## New ENV variables
N/A

---

## Checklist
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [ ] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have requested a review from at least one other dev
