### PR TITLE
DL3-113-4

### DIFF
--- a/src/main/frontend/public/index.html
+++ b/src/main/frontend/public/index.html
@@ -26,14 +26,9 @@
           nonce: '[[${nonce}]]'
         };
         console.log("issuer from deeplinking", ltiLaunchData.iss);
-        let stateAndNonceCheck = new LtiStorage().validateStateAndNonce(ltiLaunchData.state, ltiLaunchData.nonce, ltiLaunchData.iss, window);
-        stateAndNonceCheck.then(function(result) {
-            console.log("result from validateState", result);
-            if (result === true){
-              <!--/* We have to set an attribute to the root element so the APP can use the values of the LTI launch data. */-->
-              document.getElementById('root').setAttribute('lti-launch-data', JSON.stringify(ltiLaunchData));
-            }
-        });
+
+    document.getElementById('root').setAttribute('lti-launch-data', JSON.stringify(ltiLaunchData));
+
     </script>
   </body>
 </html>

--- a/src/main/frontend/src/app/ltistorage.js
+++ b/src/main/frontend/src/app/ltistorage.js
@@ -111,28 +111,13 @@ class LtiPostMessage {
             }
             const messageHandler = (event) => {
                 if (event.data.message_id !== data.message_id) {
-                    //log.error({message: 'Ignoring message, invalid message_id: [' + event.data.message_id + '] expected: [' + data.message_id + ']'});
                     return;
                 }
-                /*
-                log.response(event);
-                if (targetOrigin !== '*' && event.origin !== targetOrigin) {
-                    log.error({message: 'Ignoring message, invalid origin: ' + event.origin});
-                    return log.print();
-                }
-                if (event.data.subject !== data.subject + '.response') {
-                    log.error({message: 'Ignoring message, invalid subject: [' + event.data.subject + '] expected: [' + data.subject + '.response]'});
-                    return log.print();
-                }
-                */
                 window.removeEventListener('message', messageHandler);
                 clearTimeout(timeout);
                 if (event.data.error) {
-                    // log.error(event.data.error);
-                    // log.print();
                     return reject(event.data.error);
                 }
-                //log.print();
                 resolve(event.data);
             };
             window.addEventListener('message', messageHandler);
@@ -143,8 +128,6 @@ class LtiPostMessage {
                     code: 'timeout',
                     message: 'No response received after 1000ms'
                 };
-                // log.error(timeout_error);
-                // log.print();
                 reject(timeout_error);
             }, 1000);
         });

--- a/src/main/frontend/src/app/ltistorage.js
+++ b/src/main/frontend/src/app/ltistorage.js
@@ -60,9 +60,6 @@ class LtiStorage {
             return Promise.resolve(true);
         }
         let platformStorage = this.ltiPostMessage(platformOrigin, launchFrame);
-        console.log("validateStateAndNonce - platformStorage", platformStorage);
-        console.log("validateStateAndNonce - cookiePrefix", LtiStorage.cookiePrefix);
-        console.log("validateStateAndNonce - state", state);
         return platformStorage.getData(LtiStorage.cookiePrefix + '_state_' + state)
             .then((value) => {
                 if (!value || state !== value) {
@@ -79,8 +76,6 @@ class LtiStorage {
             .catch(() => { return false; });
     }
     ltiPostMessage(targetOrigin, launchFrame) {
-        console.log("ltiPostMessage - targetOrigin", targetOrigin);
-        console.log("ltiPostMessage - launchFrame", launchFrame);
         return new LtiPostMessage(targetOrigin, launchFrame);
     }
     setStateAndNonceCookies(state, nonce) {
@@ -103,32 +98,18 @@ class LtiPostMessage {
     }
     async sendPostMessage(data, targetWindow, originOverride, targetFrameName) {
         return new Promise((resolve, reject) => {
-            console.log("sendPostMessage - data: ", data);
-            console.log("sendPostMessage - targetWindow: ", targetWindow);
-            console.log("sendPostMessage - originOverride: ", originOverride);
-            console.log("sendPostMessage - targetFrameName: ", targetFrameName);
-
-            // let log = new LtiPostMessageLog(this.#debug);
             let timeout;
             let targetOrigin = originOverride || this._targetOrigin.origin;
-            console.log("target origin", targetOrigin);
-//            data.message_id = 'message-' + LtiPostMessage.secureRandom(15);
             let targetFrame;
             try {
                 targetFrame = this.getTargetFrame(targetWindow, targetFrameName);
             }
             catch (e) {
-                //log.error({message: 'Failed to access target frame with name: [' + targetFrameName + '] falling back to use target window - Error: [' + e + ']'});
-                console.error("sendPostMessage - error", e);
                 targetFrameName = undefined;
                 targetFrame = targetWindow;
             }
             const messageHandler = (event) => {
-                 console.log("sendPostMessage - messageHandler - event", event);
-
                 if (event.data.message_id !== data.message_id) {
-                    console.log("sendPostMessage - messageHandler (inside if) - data.message_id", data.message_id);
-                    console.log("sendPostMessage - messageHandler (inside if)- event", event);
                     //log.error({message: 'Ignoring message, invalid message_id: [' + event.data.message_id + '] expected: [' + data.message_id + ']'});
                     return;
                 }
@@ -143,22 +124,17 @@ class LtiPostMessage {
                     return log.print();
                 }
                 */
-                console.log("sendPostMessage - event.origin: ", event.origin)
                 window.removeEventListener('message', messageHandler);
                 clearTimeout(timeout);
                 if (event.data.error) {
                     // log.error(event.data.error);
                     // log.print();
-                    console.log("sendPostMessage - messageHandler - event.data.error", event.data.error);
                     return reject(event.data.error);
                 }
                 //log.print();
                 resolve(event.data);
             };
             window.addEventListener('message', messageHandler);
-            // console.log("sendPostMessage after eventListener - messageHandler", messageHandler);
-            console.log("sendPostMessage after eventListener - data", data);
-            console.log("sendPostMessage after eventListener - targetOrigin", targetOrigin);
             targetFrame.postMessage(data, targetOrigin);
             timeout = setTimeout(() => {
                 window.removeEventListener('message', messageHandler);
@@ -213,7 +189,6 @@ class LtiPostMessage {
                     }
                     // Use subject specified in capabilities for backwards compatibility
                     data.subject = capabilities.supported_messages[i].subject;
-                    console.log("sendPostMessageIfCapable - setting data.subject", data.subject);
                     // Setting the override to "*"
                     return this.sendPostMessage(
                         data,
@@ -228,7 +203,6 @@ class LtiPostMessage {
                 });
             });
     };
-
     async putData(key, value) {
         function secureRandom(length) {
             let random = new Uint8Array(length||63);
@@ -242,7 +216,6 @@ class LtiPostMessage {
           message_id: 'message-' + secureRandom(15)
         };
     };
-
     async getData(key) {
         function secureRandom(length) {
             let random = new Uint8Array(length||63);
@@ -255,8 +228,6 @@ class LtiPostMessage {
             message_id: 'message-' + secureRandom(15)
         })
             .then((response) => {
-                console.log("getData - key", key);
-                console.log("getData - response", response);
                 return response.value;
             });
     };

--- a/src/main/frontend/src/app/ltistorage.js
+++ b/src/main/frontend/src/app/ltistorage.js
@@ -1,488 +1,240 @@
-//  This code originates from 1EdTech's LTI Postmessage Example Library.
-//  We have edited this code for our use.
-//  The original can be found here: https://github.com/1EdTech/lti-postmessage-library
-
-var __classPrivateFieldSet =
-  (this && this.__classPrivateFieldSet) ||
-  function (receiver, state, value, kind, f) {
-    if (kind === "m") throw new TypeError("Private method is not writable");
-    if (kind === "a" && !f)
-      throw new TypeError("Private accessor was defined without a setter");
-    if (
-      typeof state === "function"
-        ? receiver !== state || !f
-        : !state.has(receiver)
-    )
-      throw new TypeError(
-        "Cannot write private member to an object whose class did not declare it"
-      );
-    return (
-      kind === "a"
-        ? f.call(receiver, value)
-        : f
-        ? (f.value = value)
-        : state.set(receiver, value),
-      value
-    );
-  };
-var __classPrivateFieldGet =
-  (this && this.__classPrivateFieldGet) ||
-  function (receiver, state, kind, f) {
-    if (kind === "a" && !f)
-      throw new TypeError("Private accessor was defined without a getter");
-    if (
-      typeof state === "function"
-        ? receiver !== state || !f
-        : !state.has(receiver)
-    )
-      throw new TypeError(
-        "Cannot read private member from an object whose class did not declare it"
-      );
-    return kind === "m"
-      ? f
-      : kind === "a"
-      ? f.call(receiver)
-      : f
-      ? f.value
-      : state.get(receiver);
-  };
-var _LtiStorage_instances,
-  _LtiStorage_debug,
-  _LtiStorage_setStateAndNonceCookies,
-  _LtiPostMessage_instances,
-  _LtiPostMessage_debug,
-  _LtiPostMessage_getTargetWindow,
-  _LtiPostMessage_getTargetFrame,
-  _LtiPostMessageLog_debug;
+"use strict";
 class LtiStorage {
-  constructor(debug) {
-    _LtiStorage_instances.add(this);
-    _LtiStorage_debug.set(this, void 0);
-    __classPrivateFieldSet(this, _LtiStorage_debug, debug, "f");
-  }
-  async initToolLogin(
-    platformOidcLoginUrl,
-    oidcLoginData,
-    launchFrame,
-    hasPlatformStorage
-  ) {
-    return this.setStateAndNonce(
-      platformOidcLoginUrl,
-      oidcLoginData,
-      launchFrame,
-      hasPlatformStorage
-    )
-    .then(this.doLoginInitiationRedirect);
-  }
-  async setStateAndNonce(
-    platformOidcLoginUrl,
-    oidcLoginData,
-    launchFrame,
-    hasPlatformStorage
-  ) {
-    let launchWindow = launchFrame || window;
-    let targetOrigin = new URL(platformOidcLoginUrl).origin;
-
-    return new Promise((resolve, reject) => {
-      return resolve(hasPlatformStorage);
-    })
-      .then(async (hasPlatformStorage) => {
-        if (hasPlatformStorage) {
-          let platformStorage = this.ltiPostMessage(targetOrigin, launchWindow);
-
-          return platformStorage
-            .putData(
-              LtiStorage.cookiePrefix + "_state_" + oidcLoginData.state,
-              oidcLoginData.state
-            )
-            .then((stateData) => {
-              localStorage.setItem("state", JSON.stringify(stateData)); //storing state in local storage
-              window.parent.postMessage(
-                //sending state in post message
-                stateData,
-                new URL(platformOidcLoginUrl).origin
-              );
-            })
-            .then(() => {
-              platformStorage
-                .putData(
-                  LtiStorage.cookiePrefix + "_nonce_" + oidcLoginData.nonce,
-                  oidcLoginData.nonce
-                )
-                .then((nonceData) => {
-                  localStorage.setItem("nonce", JSON.stringify(nonceData)); //storing nonce in local storage
-                  window.parent.postMessage(
-                    //sending nonce in post message
-                    nonceData,
-                    new URL(platformOidcLoginUrl).origin
-                  );
-                });
-            });
-        }
-        return Promise.reject();
-      })
-      .catch((err) => {
-        err && console.log(err);
-        return __classPrivateFieldGet(
-          this,
-          _LtiStorage_instances,
-          "m",
-          _LtiStorage_setStateAndNonceCookies
-        ).call(this, oidcLoginData.state, oidcLoginData.nonce);
-      })
-      .then((hasState) => {
-        let data = {
-          ...oidcLoginData,
-          scope: "openid",
-          response_type: "id_token",
-          response_mode: "form_post",
-          prompt: "none", // Don't prompt user on redirect.
-        };
-        return {
-          url: platformOidcLoginUrl,
-          params: data,
-          target: hasState ? "_self" : "_blank",
-        };
-      });
-  }
-  doLoginInitiationRedirect(formData) {
-    //uses formData returned from setStateAndNonce function
-    //TODO: when do we need to do this redirect?
-    let form = document.createElement("form");
-    for (let key in formData.params) {
-      let element = document.createElement("input");
-      element.type = "hidden";
-      element.value = formData.params[key];
-      element.name = key;
-      form.appendChild(element);
+    async initToolLogin(platformOidcLoginUrl, oidcLoginData, launchFrame) {
+        return this.setStateAndNonce(platformOidcLoginUrl, oidcLoginData, launchFrame)
+            .then(this.doLoginInitiationRedirect);
     }
-    form.method = "POST";
-    form.action = formData.url.toString();
-    document.body.appendChild(form);
-    form.submit();
-  }
-  async validateStateAndNonce(state, nonce, platformOrigin, launchFrame) {
-    // Check cookie first
-    if (
-          document.cookie
-            .split("; ")
-            .includes(LtiStorage.cookiePrefix + "_state_" + state + "=" + state) &&
-          document.cookie
-            .split("; ")
-            .includes(LtiStorage.cookiePrefix + "_nonce_" + nonce + "=" + nonce)
-        ) {
-          // Found state in cookie, return true
-          return Promise.resolve(true);
+    async setStateAndNonce(platformOidcLoginUrl, oidcLoginData, launchFrame) {
+        let launchWindow = launchFrame || window;
+        let state = LtiPostMessage.secureRandom();
+        let nonce = LtiPostMessage.secureRandom();
+        return new Promise((resolve, reject) => {
+            let params = new URLSearchParams(window.location.search);
+            return resolve(params.has('lti_storage_target'));
+        })
+            .then(async (hasPlatformStorage) => {
+            if (hasPlatformStorage) {
+                let platformStorage = this.ltiPostMessage(new URL(platformOidcLoginUrl.origin), launchWindow);
+                return platformStorage.putData(LtiStorage.cookiePrefix + '_state_' + state, state)
+                    .then(() => platformStorage.putData(LtiStorage.cookiePrefix + '_nonce_' + nonce, nonce));
+            }
+            return Promise.reject();
+        })
+            .catch((err) => {
+            err && console.log(err);
+            return this.setStateAndNonceCookies(state, nonce);
+        })
+            .then((hasState) => {
+            let data = {
+                ...oidcLoginData,
+                state: state,
+                nonce: nonce,
+                scope: 'openid',
+                response_type: 'id_token',
+                response_mode: 'form_post',
+                prompt: 'none', // Don't prompt user on redirect.
+            };
+            return {
+                url: platformOidcLoginUrl,
+                params: data,
+                target: hasState ? '_self' : '_blank',
+            };
+        });
+    }
+    doLoginInitiationRedirect(formData) {
+        let form = document.createElement("form");
+        for (let key in formData.params) {
+            let element = document.createElement("input");
+            element.type = 'hidden';
+            element.value = formData.params[key];
+            element.name = key;
+            form.appendChild(element);
+        }
+        ;
+        form.method = "POST";
+        form.action = formData.url.toString();
+        document.body.appendChild(form);
+        form.submit();
+    }
+    async validateStateAndNonce(state, nonce, platformOrigin, launchFrame) {
+        // Check cookie first
+        if (document.cookie.split('; ').includes(LtiStorage.cookiePrefix + '_state_' + state + '=' + state)
+            && document.cookie.split('; ').includes(LtiStorage.cookiePrefix + '_nonce_' + nonce + '=' + nonce)) {
+            // Found state in cookie, return true
+            return Promise.resolve(true);
         }
         let platformStorage = this.ltiPostMessage(platformOrigin, launchFrame);
-        return platformStorage
-          .getData(LtiStorage.cookiePrefix + "_state_" + state)
-          .then((value) => {
+        console.log("platformStorage var", platformStorage);
+        console.log("platformStorage cookiePrefix", LtiStorage.cookiePrefix);
+        console.log("platformStorage state", state);
+        return platformStorage.getData(LtiStorage.cookiePrefix + '_state_' + state)
+            .then((value) => {
             if (!value || state !== value) {
-              return Promise.reject();
+                console.log("platformStorage value 2", value);
+                console.log("platformStorage state 2", state);
+                return Promise.reject();
             }
-            return platformStorage.getData(
-              LtiStorage.cookiePrefix + "_nonce_" + nonce
-            );
-          })
-          .then((value) => {
+            return platformStorage.getData(LtiStorage.cookiePrefix + '_nonce_' + nonce);
+        })
+            .then((value) => {
             if (!value || nonce !== value) {
-              return Promise.reject();
+                console.log("platformStorage value 2", value);
+                console.log("platformStorage nonce 2", nonce);
+                return Promise.reject();
             }
             return true;
-          })
-          .catch(() => {
-            return false;
-          });
-  }
-  ltiPostMessage(targetOrigin, launchFrame) {
-    return new LtiPostMessage(
-      targetOrigin,
-      launchFrame,
-      __classPrivateFieldGet(this, _LtiStorage_debug, "f")
-    );
-  }
-}
-
-LtiStorage.cookiePrefix = "lti";
-
-class LtiPostMessage {
-  constructor(targetOrigin, launchFrame, debug) {
-    _LtiPostMessage_instances.add(this);
-    _LtiPostMessage_debug.set(this, false);
-    __classPrivateFieldSet(this, _LtiPostMessage_debug, debug, "f");
-    this._targetOrigin = targetOrigin;
-    this._launchFrame = launchFrame || window;
-  }
-
-  async sendPostMessage(data, targetWindow, originOverride, targetFrameName) {
-    return new Promise((resolve, reject) => {
-      let log = new LtiPostMessageLog(
-        __classPrivateFieldGet(this, _LtiPostMessage_debug, "f")
-      );
-      let timeout;
-      let targetOrigin = originOverride || this._targetOrigin.origin;
-      let targetFrame;
-      try {
-        targetFrame = __classPrivateFieldGet(
-          this,
-          _LtiPostMessage_instances,
-          "m",
-          _LtiPostMessage_getTargetFrame
-        ).call(this, targetWindow, targetFrameName);
-      } catch (e) {
-        log.error({
-          message:
-            "Failed to access target frame with name: [" +
-            targetFrameName +
-            "] falling back to use target window - Error: [" +
-            e +
-            "]",
-        });
-        targetFrameName = undefined;
-        targetFrame = targetWindow;
-      }
-      const messageHandler = (event) => {
-        if (event.data.message_id !== data.message_id) {
-          log.error({
-            message:
-              "Ignoring message, invalid message_id: [" +
-              event.data.message_id +
-              "] expected: [" +
-              data.message_id +
-              "]",
-          });
-          return;
-        }
-        log.response(event);
-        if (targetOrigin !== "*" && event.origin !== targetOrigin) {
-          log.error({
-            message: "Ignoring message, invalid origin: " + event.origin,
-          });
-          return log.print();
-        }
-        if (event.data.subject !== data.subject + ".response") {
-          log.error({
-            message:
-              "Ignoring message, invalid subject: [" +
-              event.data.subject +
-              "] expected: [" +
-              data.subject +
-              ".response]",
-          });
-          return log.print();
-        }
-        window.removeEventListener("message", messageHandler);
-        clearTimeout(timeout);
-        if (event.data.error) {
-          log.error(event.data.error);
-          log.print();
-          return reject(event.data.error);
-        }
-        log.print();
-        resolve(event.data);
-      };
-      window.addEventListener("message", messageHandler);
-      log.request(targetFrameName, data, targetOrigin);
-      targetFrame.postMessage(data, targetOrigin);
-      timeout = setTimeout(() => {
-        window.removeEventListener("message", messageHandler);
-        let timeout_error = {
-          code: "timeout",
-          message: "No response received after 1000ms",
-        };
-        log.error(timeout_error);
-        log.print();
-        reject(timeout_error);
-      }, 1000);
-    });
-  }
-  async sendPostMessageIfCapable(data) {
-    // Call capability service
-    return Promise.any([
-      this.sendPostMessage(
-        { subject: "lti.capabilities" },
-        __classPrivateFieldGet(
-          this,
-          _LtiPostMessage_instances,
-          "m",
-          _LtiPostMessage_getTargetWindow
-        ).call(this),
-        "*"
-      ),
-      // Send new and old capabilities messages for support with pre-release subjects
-      this.sendPostMessage(
-        { subject: "org.imsglobal.lti.capabilities" },
-        __classPrivateFieldGet(
-          this,
-          _LtiPostMessage_instances,
-          "m",
-          _LtiPostMessage_getTargetWindow
-        ).call(this),
-        "*"
-      ),
-    ]).then((capabilities) => {
-      if (typeof capabilities.supported_messages == "undefined") {
-        return Promise.reject({
-          code: "not_found",
-          message: "No capabilities",
-        });
-      }
-      for (let i = 0; i < capabilities.supported_messages.length; i++) {
-        if (
-          ![data.subject, "org.imsglobal." + data.subject].includes(
-            capabilities.supported_messages[i].subject
-          )
-        ) {
-          continue;
-        }
-        // Use subject specified in capabilities for backwards compatibility
-        data.subject = capabilities.supported_messages[i].subject;
-        return this.sendPostMessage(
-          data,
-          __classPrivateFieldGet(
-            this,
-            _LtiPostMessage_instances,
-            "m",
-            _LtiPostMessage_getTargetWindow
-          ).call(this),
-          "*",
-          capabilities.supported_messages[i].frame
-        );
-      }
-      return Promise.reject({
-        code: "not_found",
-        message: "Capabilities not found",
-      });
-    });
-  }
-  async putData(key, value) {
-    function secureRandom(length) {
-      let random = new Uint8Array(length||63);
-      crypto.getRandomValues(random);
-      return btoa(String.fromCharCode(...random)).replace(/\//g, '_').replace(/\+/g, '-');
+        })
+            .catch(() => { return false; });
     }
-    return {
-      subject: "lti.put_data",
-      key: key,
-      value: value,
-      message_id: 'message-' + secureRandom(15)
-    };
-  }
-
-  async getData(key) {
-  function secureRandom(length) {
-        let random = new Uint8Array(length||63);
+    ltiPostMessage(targetOrigin, launchFrame) {
+        console.log("ltiPostMessage - targetOrigin", targetOrigin);
+        console.log("ltiPostMessage - launchFrame", launchFrame);
+        return new LtiPostMessage(targetOrigin, launchFrame);
+    }
+    setStateAndNonceCookies(state, nonce) {
+        document.cookie = LtiStorage.cookiePrefix + '_state_' + state + '=' + state + '; path=/; samesite=none; secure; expires=' + (new Date(Date.now() + 300 * 1000)).toUTCString();
+        document.cookie = LtiStorage.cookiePrefix + '_nonce_' + nonce + '=' + nonce + '; path=/; samesite=none; secure; expires=' + (new Date(Date.now() + 300 * 1000)).toUTCString();
+        return document.cookie.split('; ').includes(LtiStorage.cookiePrefix + '_state_' + state + '=' + state)
+            && document.cookie.split('; ').includes(LtiStorage.cookiePrefix + '_nonce_' + nonce + '=' + nonce);
+    }
+}
+LtiStorage.cookiePrefix = 'lti';
+class LtiPostMessage {
+    constructor(targetOrigin, launchFrame) {
+        this._targetOrigin = targetOrigin;
+        this._launchFrame = launchFrame || window;
+    }
+    static secureRandom(length) {
+        let random = new Uint8Array(length || 63);
         crypto.getRandomValues(random);
         return btoa(String.fromCharCode(...random)).replace(/\//g, '_').replace(/\+/g, '-');
-      };
-    return this.sendPostMessageIfCapable({
-      subject: "lti.get_data",
-      key: key,
-      message_id: 'message-' + secureRandom(15)
-    }).then((response) => {
-      return response.value;
-    });
-  }
+    }
+    async sendPostMessage(data, targetWindow, originOverride, targetFrameName) {
+        return new Promise((resolve, reject) => {
+            // let log = new LtiPostMessageLog(this.#debug);
+            let timeout;
+            let targetOrigin = originOverride || this._targetOrigin.origin;
+            data.message_id = 'message-' + LtiPostMessage.secureRandom(15);
+            let targetFrame;
+            try {
+                targetFrame = this.getTargetFrame(targetWindow, targetFrameName);
+            }
+            catch (e) {
+                //log.error({message: 'Failed to access target frame with name: [' + targetFrameName + '] falling back to use target window - Error: [' + e + ']'});
+                console.error("sendPostMessage - error", e);
+                targetFrameName = undefined;
+                targetFrame = targetWindow;
+            }
+            const messageHandler = (event) => {
+                if (event.data.message_id !== data.message_id) {
+                    console.log("messageHandler - data.message_id", data.message_id);
+                    console.log("messageHandler - event", event);
+                    console.log("messageHandler - data.message_id", data.message_id);
+                    //log.error({message: 'Ignoring message, invalid message_id: [' + event.data.message_id + '] expected: [' + data.message_id + ']'});
+                    return;
+                }
+                /*
+                log.response(event);
+                if (targetOrigin !== '*' && event.origin !== targetOrigin) {
+                    log.error({message: 'Ignoring message, invalid origin: ' + event.origin});
+                    return log.print();
+                }
+                if (event.data.subject !== data.subject + '.response') {
+                    log.error({message: 'Ignoring message, invalid subject: [' + event.data.subject + '] expected: [' + data.subject + '.response]'});
+                    return log.print();
+                }
+                */
+                window.removeEventListener('message', messageHandler);
+                clearTimeout(timeout);
+                if (event.data.error) {
+                    // log.error(event.data.error);
+                    // log.print();
+                    return reject(event.data.error);
+                }
+                //log.print();
+                resolve(event.data);
+            };
+            window.addEventListener('message', messageHandler);
+            //log.request(targetFrameName, data, targetOrigin);
+            targetFrame.postMessage(data, targetOrigin);
+            timeout = setTimeout(() => {
+                window.removeEventListener('message', messageHandler);
+                let timeout_error = {
+                    code: 'timeout',
+                    message: 'No response received after 1000ms'
+                };
+                // log.error(timeout_error);
+                // log.print();
+                reject(timeout_error);
+            }, 1000);
+        });
+    }
+    ;
+    async sendPostMessageIfCapable(data) {
+        // Call capability service
+        return Promise.any([
+            this.sendPostMessage({ subject: 'lti.capabilities' }, this.getTargetWindow(), '*'),
+            // Send new and old capabilities messages for support with pre-release subjects
+            this.sendPostMessage({ subject: 'org.imsglobal.lti.capabilities' }, this.getTargetWindow(), '*')
+        ])
+            .then((capabilities) => {
+            if (typeof capabilities.supported_messages == 'undefined') {
+                return Promise.reject({
+                    code: 'not_found',
+                    message: 'No capabilities'
+                });
+            }
+            console.log("sendPostMessageIfCapable - data", data);
+            console.log("sendPostMessageIfCapable - capabilities", capabilities);
+            console.log("sendPostMessageIfCapable - target window", this.getTargetWindow());
+            for (let i = 0; i < capabilities.supported_messages.length; i++) {
+                if (![data.subject, 'org.imsglobal.' + data.subject].includes(capabilities.supported_messages[i].subject)) {
+                    continue;
+                }
+                // Use subject specified in capabilities for backwards compatibility
+                data.subject = capabilities.supported_messages[i].subject;
+                return this.sendPostMessage(data, this.getTargetWindow(), undefined, capabilities.supported_messages[i].frame);
+            }
+            return Promise.reject({
+                code: 'not_found',
+                message: 'Capabilities not found'
+            });
+        });
+    }
+    ;
+    async putData(key, value) {
+        return this.sendPostMessageIfCapable({
+            subject: 'lti.put_data',
+            key: key,
+            value: value
+        })
+            .then((response) => {
+            return true;
+        });
+    }
+    ;
+    async getData(key) {
+        return this.sendPostMessageIfCapable({
+            subject: 'lti.get_data',
+            key: key
+        })
+            .then((response) => {
+            console.log("getData key", key);
+            console.log("getData response", response);
+            return response.value;
+        });
+    }
+    ;
+    getTargetWindow() {
+        return this._launchFrame.opener || this._launchFrame.parent;
+    }
+    ;
+    getTargetFrame(targetWindow, frameName) {
+        if (frameName && targetWindow.frames[frameName]) {
+            return targetWindow.frames[frameName];
+        }
+        return targetWindow;
+    }
 }
 
-class LtiPostMessageLog {
-  constructor(debug) {
-    _LtiPostMessageLog_debug.set(this, false);
-    this._request = {};
-    this._response = {};
-    this._error = [];
-    this._start_time = Date.now();
-    __classPrivateFieldSet(this, _LtiPostMessageLog_debug, debug, "f");
-  }
-
-  request(targetFrameName, data, targetOrigin) {
-    this._request = {
-      timestamp: Date.now(),
-      targetFrameName: targetFrameName,
-      data: data,
-      targetOrigin: targetOrigin,
-    };
-  }
-  response(event) {
-    this._response = {
-      timestamp: Date.now(),
-      origin: event.origin,
-      data: event.data,
-      event: event,
-    };
-  }
-  error(error) {
-    this._error[this._error.length] = {
-      error: error,
-      timestamp: Date.now(),
-    };
-  }
-  print() {
-    if (!__classPrivateFieldGet(this, _LtiPostMessageLog_debug, "f")) {
-      return;
-    }
-    let reqTime = Date.now() - this._start_time;
-    console.groupCollapsed(
-      "%c %c request time: " +
-        reqTime +
-        (this._request.timestamp ? "ms\t " + this._request.data.subject : ""),
-      "padding-left:" +
-        Math.min(reqTime, 100) * 6 +
-        "px; background-color: " +
-        (this._error.length
-          ? this._response.timestamp
-            ? "orange"
-            : "red"
-          : "green") +
-        ";",
-      "padding-left:" +
-        (10 + Math.max(0, 10 - reqTime) * 6) +
-        "px; background-color: transparent"
-    );
-    if (this._request.timestamp) {
-      console.groupCollapsed(
-        "Request " +
-          " - timestamp: " +
-          this._request.timestamp +
-          " - message_id: " +
-          this._request.data.message_id +
-          " - action: " +
-          this._request.data.subject +
-          " - origin: " +
-          this._request.targetOrigin +
-          (this._request.targetFrameName
-            ? " - target: " + this._request.targetFrameName
-            : "")
-      );
-      console.log("Sent from: " + window.location.href);
-      console.log(JSON.stringify(this._request.data, null, "    "));
-      console.groupEnd();
-    }
-    if (this._response.timestamp) {
-      console.groupCollapsed(
-        "Response" +
-          " - timestamp: " +
-          this._response.timestamp +
-          " - message_id: " +
-          this._response.data.message_id +
-          " - action: " +
-          this._response.data.subject +
-          " - origin: " +
-          this._response.origin
-      );
-      console.log(JSON.stringify(this._response.data, null, "    "));
-      console.groupEnd();
-    }
-    if (this._error.length) {
-      console.groupCollapsed(
-        this._error.length + " Error" + (this._error.length > 1 ? "s" : "")
-      );
-      for (let i = 0; i < this._error.length; i++) {
-        console.log(this._error[i].error.message || this._error[i].error);
-      }
-      console.groupEnd();
-    }
-    console.groupEnd();
-  }
-}
+export default LtiStorage;

--- a/src/main/frontend/src/app/ltistorage.js
+++ b/src/main/frontend/src/app/ltistorage.js
@@ -193,12 +193,8 @@ class LtiPostMessage {
                     message: 'No capabilities'
                 });
             }
-//            console.log("sendPostMessageIfCapable - data", data);
-//            console.log("sendPostMessageIfCapable - capabilities", capabilities);
-//            console.log("sendPostMessageIfCapable - target window", this.getTargetWindow());
+
             for (let i = 0; i < capabilities.supported_messages.length; i++) {
-                console.log("sendPostMessageIfCapable - data.subject", data.subject);
-                console.log("sendPostMessageIfCapable - capabilities.supported_messages", capabilities.supported_messages[i].subject);
                 if (![data.subject, 'org.imsglobal.' + data.subject].includes(capabilities.supported_messages[i].subject)) {
                     continue;
                 }

--- a/src/main/frontend/src/app/ltistorage.js
+++ b/src/main/frontend/src/app/ltistorage.js
@@ -6,8 +6,6 @@ class LtiStorage {
     }
     async setStateAndNonce(platformOidcLoginUrl, oidcLoginData, launchFrame) {
         let launchWindow = launchFrame || window;
-        let state = LtiPostMessage.secureRandom();
-        let nonce = LtiPostMessage.secureRandom();
         return new Promise((resolve, reject) => {
             let params = new URLSearchParams(window.location.search);
             return resolve(params.has('lti_storage_target'));
@@ -15,20 +13,18 @@ class LtiStorage {
             .then(async (hasPlatformStorage) => {
             if (hasPlatformStorage) {
                 let platformStorage = this.ltiPostMessage(new URL(platformOidcLoginUrl.origin), launchWindow);
-                return platformStorage.putData(LtiStorage.cookiePrefix + '_state_' + state, state)
-                    .then(() => platformStorage.putData(LtiStorage.cookiePrefix + '_nonce_' + nonce, nonce));
+                return platformStorage.putData(LtiStorage.cookiePrefix + '_state_' + oidcLoginData.state, oidcLoginData.state)
+                    .then(() => platformStorage.putData(LtiStorage.cookiePrefix + '_nonce_' + oidcLoginData.nonce, oidcLoginData.nonce));
             }
             return Promise.reject();
         })
             .catch((err) => {
             err && console.log(err);
-            return this.setStateAndNonceCookies(state, nonce);
+            return this.setStateAndNonceCookies(oidcLoginData.state, oidcLoginData.nonce);
         })
             .then((hasState) => {
             let data = {
                 ...oidcLoginData,
-                state: state,
-                nonce: nonce,
                 scope: 'openid',
                 response_type: 'id_token',
                 response_mode: 'form_post',

--- a/src/main/frontend/src/app/ltistorage.js
+++ b/src/main/frontend/src/app/ltistorage.js
@@ -1,5 +1,6 @@
 
 class LtiStorage {
+    // We never use the initToolLogin method from this file but keeping it here for now
     async initToolLogin(platformOidcLoginUrl, oidcLoginData, launchFrame) {
         return this.setStateAndNonce(platformOidcLoginUrl, oidcLoginData, launchFrame)
             .then(this.doLoginInitiationRedirect);

--- a/src/main/frontend/src/index.js
+++ b/src/main/frontend/src/index.js
@@ -61,7 +61,6 @@ store.dispatch(fetchCourses(1));
 
 let stateAndNonceCheck = new LtiStorage().validateStateAndNonce(ltiLaunchData.state, ltiLaunchData.nonce, ltiLaunchData.iss, window);
 stateAndNonceCheck.then(function(result) {
-    console.log("result from validateState", result);
     if (result === true){
       root.render(
         <React.StrictMode>

--- a/src/main/frontend/src/index.js
+++ b/src/main/frontend/src/index.js
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import appSlice from './app/appSlice';
 import { fetchCourses } from './app/appSlice';
+import LtiStorage from './app/ltistorage';
 import { isValidRootOutcomeGuid } from './util/Utils.js';
 
 // Components import
@@ -58,15 +59,24 @@ const store = configureStore({
 // Once the store is configured, load the courses from the backend.
 store.dispatch(fetchCourses(1));
 
-root.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <ThemeProvider breakpoints={['xs', 'xxs','sm']}>
-        <App />
-      </ThemeProvider>
-    </Provider>
-  </React.StrictMode>
-);
+let stateAndNonceCheck = new LtiStorage().validateStateAndNonce(ltiLaunchData.state, ltiLaunchData.nonce, ltiLaunchData.iss, window);
+stateAndNonceCheck.then(function(result) {
+    console.log("result from validateState", result);
+    if (result === true){
+      root.render(
+        <React.StrictMode>
+          <Provider store={store}>
+            <ThemeProvider breakpoints={['xs', 'xxs','sm']}>
+              <App />
+            </ThemeProvider>
+          </Provider>
+        </React.StrictMode>
+      );
+    }
+});
+
+
+
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))

--- a/src/main/frontend/src/index.js
+++ b/src/main/frontend/src/index.js
@@ -72,6 +72,7 @@ stateAndNonceCheck.then(function(result) {
         </React.StrictMode>
       );
     }
+    // TODO: If result === false then we will want to redirect to the error page here
 });
 
 

--- a/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
@@ -199,10 +199,6 @@ public class LTI3Controller {
                 model.addAttribute("platform_family_code", lti3Request.getLtiToolPlatformFamilyCode());
                 model.addAttribute("ltiServiceUrl", ltiDataService.getLocalUrl());
             } else {
-                String iss = lti3Request.getIss();
-                log.debug("issuer---");
-                log.debug(iss);
-
                 model.addAttribute("lti_storage_target", req.getParameter("lti_storage_target"));
                 model.addAttribute("state", state);
                 model.addAttribute("iss", lti3Request.getIss());
@@ -234,9 +230,6 @@ public class LTI3Controller {
                     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Deep Linking Disabled");
                 }
             }
-            String iss = lti3Request.getIss();
-            log.debug("issuer---");
-            log.debug(iss);
 
             model.addAttribute("lti_storage_target", req.getParameter("lti_storage_target"));
             model.addAttribute("state", state);

--- a/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
+++ b/src/main/java/net/unicon/lti/controller/lti/LTI3Controller.java
@@ -199,6 +199,10 @@ public class LTI3Controller {
                 model.addAttribute("platform_family_code", lti3Request.getLtiToolPlatformFamilyCode());
                 model.addAttribute("ltiServiceUrl", ltiDataService.getLocalUrl());
             } else {
+                String iss = lti3Request.getIss();
+                log.debug("issuer---");
+                log.debug(iss);
+
                 model.addAttribute("lti_storage_target", req.getParameter("lti_storage_target"));
                 model.addAttribute("state", state);
                 model.addAttribute("iss", lti3Request.getIss());
@@ -230,14 +234,14 @@ public class LTI3Controller {
                     throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Deep Linking Disabled");
                 }
             }
+            String iss = lti3Request.getIss();
+            log.debug("issuer---");
+            log.debug(iss);
 
             model.addAttribute("lti_storage_target", req.getParameter("lti_storage_target"));
             model.addAttribute("state", state);
             model.addAttribute("nonce", lti3Request.getNonce());
             model.addAttribute("iss", lti3Request.getIss());
-            String iss = lti3Request.getIss();
-            log.debug("issuer---");
-            log.debug(iss);
             return "lti3Redirect";
 
         } catch (SignatureException e) {

--- a/src/main/resources/static/js/ltistorage.js
+++ b/src/main/resources/static/js/ltistorage.js
@@ -175,6 +175,7 @@ class LtiStorage {
           // Found state in cookie, return true
           return Promise.resolve(true);
         }
+        console.log("postMessage_instance", _LtiPostMessage_instances);
         let platformStorage = this.ltiPostMessage(platformOrigin, launchFrame);
         return platformStorage
           .getData(LtiStorage.cookiePrefix + "_state_" + state)

--- a/src/main/resources/static/js/ltistorage.js
+++ b/src/main/resources/static/js/ltistorage.js
@@ -318,6 +318,7 @@ class LtiPostMessage {
         window.removeEventListener("message", messageHandler);
         clearTimeout(timeout);
         if (event.data.error) {
+         console.log("sendPostMessage - messageHandler - event.data.error", event.data.error);
           log.error(event.data.error);
           log.print();
           return reject(event.data.error);
@@ -343,10 +344,19 @@ class LtiPostMessage {
     });
   }
   async sendPostMessageIfCapable(data) {
+      function secureRandom(length) {
+        let random = new Uint8Array(length||63);
+        crypto.getRandomValues(random);
+        return btoa(String.fromCharCode(...random)).replace(/\//g, '_').replace(/\+/g, '-');
+      }
+
     // Call capability service
     return Promise.any([
       this.sendPostMessage(
-        { subject: "lti.capabilities" },
+        {
+            subject: 'lti.capabilities',
+            message_id: 'message-' + secureRandom(15)
+        },
         __classPrivateFieldGet(
           this,
           _LtiPostMessage_instances,
@@ -357,7 +367,10 @@ class LtiPostMessage {
       ),
       // Send new and old capabilities messages for support with pre-release subjects
       this.sendPostMessage(
-        { subject: "org.imsglobal.lti.capabilities" },
+        {
+            subject: "org.imsglobal.lti.capabilities",
+            message_id: 'message-' + secureRandom(15)
+         },
         __classPrivateFieldGet(
           this,
           _LtiPostMessage_instances,

--- a/src/main/resources/static/js/ltistorage.js
+++ b/src/main/resources/static/js/ltistorage.js
@@ -251,6 +251,11 @@ class LtiPostMessage {
 
   async sendPostMessage(data, targetWindow, originOverride, targetFrameName) {
     return new Promise((resolve, reject) => {
+
+        console.log("sendPostMessage - data: ", data);
+        console.log("sendPostMessage - targetWindow: ", targetWindow);
+        console.log("sendPostMessage - originOverride: ", originOverride);
+        console.log("sendPostMessage - targetFrameName: ", targetFrameName);
       let log = new LtiPostMessageLog(
         __classPrivateFieldGet(this, _LtiPostMessage_debug, "f")
       );
@@ -290,6 +295,7 @@ class LtiPostMessage {
           return;
         }
         log.response(event);
+        console.log("sendPostMessage - event.origin: ", event.origin)
         if (targetOrigin !== "*" && event.origin !== targetOrigin) {
           log.error({
             message: "Ignoring message, invalid origin: " + event.origin,
@@ -318,6 +324,8 @@ class LtiPostMessage {
         resolve(event.data);
       };
       window.addEventListener("message", messageHandler);
+      console.log("sendPostMessage after eventListener - data", data);
+      console.log("sendPostMessage after eventListener - targetOrigin", targetOrigin);
       log.request(targetFrameName, data, targetOrigin);
       targetFrame.postMessage(data, targetOrigin);
       timeout = setTimeout(() => {

--- a/src/main/resources/static/js/ltistorage.js
+++ b/src/main/resources/static/js/ltistorage.js
@@ -175,8 +175,9 @@ class LtiStorage {
           // Found state in cookie, return true
           return Promise.resolve(true);
         }
-        console.log("postMessage_instance", _LtiPostMessage_instances);
+        console.log("validateStateAndNonce - platformOrigin", platformOrigin);
         let platformStorage = this.ltiPostMessage(platformOrigin, launchFrame);
+
         return platformStorage
           .getData(LtiStorage.cookiePrefix + "_state_" + state)
           .then((value) => {
@@ -198,6 +199,8 @@ class LtiStorage {
           });
   }
   ltiPostMessage(targetOrigin, launchFrame) {
+    console.log("ltiPostMessage - targetOrigin", targetOrigin);
+    console.log("ltiPostMessage - launchFrame", launchFrame);
     return new LtiPostMessage(
       targetOrigin,
       launchFrame,
@@ -245,23 +248,17 @@ class LtiPostMessage {
     _LtiPostMessage_debug.set(this, false);
     __classPrivateFieldSet(this, _LtiPostMessage_debug, debug, "f");
     this._targetOrigin = new URL(targetOrigin);
-    console.log("constructor: ", this._targetOrigin);
     this._launchFrame = launchFrame || window;
   }
 
   async sendPostMessage(data, targetWindow, originOverride, targetFrameName) {
     return new Promise((resolve, reject) => {
-
-        console.log("sendPostMessage - data: ", data);
-        console.log("sendPostMessage - targetWindow: ", targetWindow);
-        console.log("sendPostMessage - originOverride: ", originOverride);
-        console.log("sendPostMessage - targetFrameName: ", targetFrameName);
       let log = new LtiPostMessageLog(
         __classPrivateFieldGet(this, _LtiPostMessage_debug, "f")
       );
       let timeout;
       let targetOrigin = originOverride || this._targetOrigin.origin;
-      console.log("target origin", targetOrigin);
+      console.log("sendPostMessage --- target origin", targetOrigin);
       let targetFrame;
       try {
         targetFrame = __classPrivateFieldGet(
@@ -295,14 +292,19 @@ class LtiPostMessage {
           return;
         }
         log.response(event);
-        console.log("sendPostMessage - event.origin: ", event.origin)
+        console.log("sendPostMessage - event.origin: ", event.origin);
+        console.log("sendPostMessage - targetOrigin: ", targetOrigin);
         if (targetOrigin !== "*" && event.origin !== targetOrigin) {
+           console.log("sendPostMessage - error 1 (event.origin): ", event.origin);
+           console.log("sendPostMessage - error 1 (targetOrigin): ", targetOrigin);
           log.error({
             message: "Ignoring message, invalid origin: " + event.origin,
           });
           return log.print();
         }
         if (event.data.subject !== data.subject + ".response") {
+           console.log("sendPostMessage - error 2 (event.data.subject): ", event.data.subject);
+           console.log("sendPostMessage - error 2 (data.subject): ", data.subject);
           log.error({
             message:
               "Ignoring message, invalid subject: [" +

--- a/src/main/resources/static/js/ltistorage.js
+++ b/src/main/resources/static/js/ltistorage.js
@@ -175,7 +175,6 @@ class LtiStorage {
           // Found state in cookie, return true
           return Promise.resolve(true);
         }
-        console.log("validateStateAndNonce - platformOrigin", platformOrigin);
         let platformStorage = this.ltiPostMessage(platformOrigin, launchFrame);
 
         return platformStorage
@@ -199,8 +198,6 @@ class LtiStorage {
           });
   }
   ltiPostMessage(targetOrigin, launchFrame) {
-    console.log("ltiPostMessage - targetOrigin", targetOrigin);
-    console.log("ltiPostMessage - launchFrame", launchFrame);
     return new LtiPostMessage(
       targetOrigin,
       launchFrame,
@@ -258,7 +255,6 @@ class LtiPostMessage {
       );
       let timeout;
       let targetOrigin = originOverride || this._targetOrigin.origin;
-      console.log("sendPostMessage --- target origin", targetOrigin);
       let targetFrame;
       try {
         targetFrame = __classPrivateFieldGet(
@@ -292,19 +288,13 @@ class LtiPostMessage {
           return;
         }
         log.response(event);
-        console.log("sendPostMessage - event.origin: ", event.origin);
-        console.log("sendPostMessage - targetOrigin: ", targetOrigin);
         if (targetOrigin !== "*" && event.origin !== targetOrigin) {
-           console.log("sendPostMessage - error 1 (event.origin): ", event.origin);
-           console.log("sendPostMessage - error 1 (targetOrigin): ", targetOrigin);
           log.error({
             message: "Ignoring message, invalid origin: " + event.origin,
           });
           return log.print();
         }
         if (event.data.subject !== data.subject + ".response") {
-           console.log("sendPostMessage - error 2 (event.data.subject): ", event.data.subject);
-           console.log("sendPostMessage - error 2 (data.subject): ", data.subject);
           log.error({
             message:
               "Ignoring message, invalid subject: [" +
@@ -318,7 +308,6 @@ class LtiPostMessage {
         window.removeEventListener("message", messageHandler);
         clearTimeout(timeout);
         if (event.data.error) {
-         console.log("sendPostMessage - messageHandler - event.data.error", event.data.error);
           log.error(event.data.error);
           log.print();
           return reject(event.data.error);
@@ -327,8 +316,6 @@ class LtiPostMessage {
         resolve(event.data);
       };
       window.addEventListener("message", messageHandler);
-      console.log("sendPostMessage after eventListener - data", data);
-      console.log("sendPostMessage after eventListener - targetOrigin", targetOrigin);
       log.request(targetFrameName, data, targetOrigin);
       targetFrame.postMessage(data, targetOrigin);
       timeout = setTimeout(() => {

--- a/src/main/resources/static/js/ltistorage.js
+++ b/src/main/resources/static/js/ltistorage.js
@@ -176,7 +176,6 @@ class LtiStorage {
           return Promise.resolve(true);
         }
         let platformStorage = this.ltiPostMessage(platformOrigin, launchFrame);
-
         return platformStorage
           .getData(LtiStorage.cookiePrefix + "_state_" + state)
           .then((value) => {

--- a/src/main/resources/templates/lti3Redirect.html
+++ b/src/main/resources/templates/lti3Redirect.html
@@ -26,7 +26,7 @@
     <script th:inline="javascript">
         let state = [[${ state }]];
         let nonce = [[${ nonce }]];
-        let platformOrigin = [[${ iss }]]
+        let platformOrigin = [[${ iss }]];
 
         let stateAndNonceCheck = new LtiStorage().validateStateAndNonce(state, nonce, platformOrigin, window)
         stateAndNonceCheck.then(function(result) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including your Jira ticket ID. -->

## Description
<!--- Describe the "what" behind your changes. -->
These are the latest updates to merge into `DL3-133-redirect`. These changes now allow both Canvas and D2L to successfully do both standard launches and deeplinking launches.

Things we did in the PR:
- We moved the call to the `ltistorage.js` from the `index.html` into the `index.js`
    - To do this we added an export to the `src/main/frontend/src/app/ltistorage.js` and require it in the `index.js`
- Pat also removed the logging functions out of this version of the `ltistorage.js` and removed the private variables
    - (Pat did other things too)

- For D2L we also needed to add in the `message_id` to the capabilities requests

The next ticket that Emily will work on will hopefully resolve the issues with BB not passing over the `lti_storage_target` on the call to the `/lti3/` endpoint 🎉

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


### Fixes
[DL3-113](https://lumenlearning.atlassian.net/browse/DL3-113)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to see how your change affects other areas of the code, etc. -->
Tested locally and on dev-env
All tests pass

## Screenshots

---
<!-- The following section calls out any changes that will impact the deploy of this PR and/or need to be shared with the team post-deploy. It is not meant to be all-inclusive; if there are additional things to note here, make a heading and do so :) -->

## Database changes
<!-- Describe any database changes here. -->

## ⚠️ Deployment instructions ⚠️
<!-- Make note of any unique-to-this-PR deployment instructions here. -->

## New ENV variables
<!-- Document any new ENV variables added as part of this work -->

---

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have reviewed the AC for this feature and my changes meet all requirements
- [ ] (For UI changes) I have considered the accessibility of this feature (see https://www.a11yproject.com/checklist/ for a high-level checklist)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have requested a review from at least one other dev


[DL3-113]: https://lumenlearning.atlassian.net/browse/DL3-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ